### PR TITLE
Added required attributes to example conf file.

### DIFF
--- a/conf/appdaemon.yaml.example
+++ b/conf/appdaemon.yaml.example
@@ -1,4 +1,8 @@
 appdaemon:
+  latitude: 0
+  longitude: 0
+  elevation: 30
+  time_zone: Europe/Berlin
   plugins:
     HASS:
       type: hass


### PR DESCRIPTION
Attributes latitude, longitude, elevation and time_zone are required. Lack of them prevents the app from starting.

This can be confusing for new users following the installation manual, as those attributes are nowhere mentioned.