### PR TITLE
Hass get history Update

### DIFF
--- a/appdaemon/plugins/hass/hassapi.py
+++ b/appdaemon/plugins/hass/hassapi.py
@@ -707,7 +707,7 @@ class Hass(adbase.ADBase, adapi.ADAPI):
                 In most cases it is safe to ignore this parameter.
 
         Returns:
-            An iterable list of entity_ids and their history state.
+            An iterable list of entity_ids and their history state or task future object if callback supplied.
 
         Examples:
             Get device state over the last 5 days.
@@ -736,7 +736,7 @@ class Hass(adbase.ADBase, adapi.ADAPI):
         if hasattr(plugin, "get_history"):
             callback = kwargs.pop("callback", None)
             if callback is not None and callable(callback):
-                self.create_task(plugin.get_history(**kwargs), callback)
+                return await self.create_task(plugin.get_history(**kwargs), callback)
 
             else:
                 return await plugin.get_history(**kwargs)

--- a/appdaemon/plugins/hass/hassapi.py
+++ b/appdaemon/plugins/hass/hassapi.py
@@ -664,9 +664,8 @@ class Hass(adbase.ADBase, adapi.ADAPI):
 
     @hass_check
     @utils.sync_wrapper
-    async def get_history(self, entity_id="", **kwargs):
+    async def get_history(self, **kwargs):
         """Gets access to the HA Database.
-
         This is a convenience function that allows accessing the HA Database, so the
         history state of a device can be retrieved. It allows for a level of flexibility
         when retrieving the data, and returns it as a dictionary list. Caution must be
@@ -674,16 +673,16 @@ class Hass(adbase.ADBase, adapi.ADAPI):
         a long time to process.
 
         Args:
-            entity_id (str): Fully qualified id of the device to be querying, e.g.,
+            **kwargs (optional): Zero or more keyword arguments.
+
+        Keyword Args:
+            entity_id (str, optional): Fully qualified id of the device to be querying, e.g.,
                 ``light.office_lamp`` or ``scene.downstairs_on`` This can be any entity_id
                 in the database. If this is left empty, the state of all entities will be
                 retrieved within the specified time. If both ``end_time`` and ``start_time``
                 explained below are declared, and ``entity_id`` is specified, the specified
                 ``entity_id`` will be ignored and the history states of `all` entity_id in
                 the database will be retrieved within the specified time.
-            **kwargs (optional): Zero or more keyword arguments.
-
-        Keyword Args:
             days (int, optional): The days from the present-day walking backwards that is
                 required from the database.
             start_time (optional): The start time from when the data should be retrieved.
@@ -699,6 +698,10 @@ class Hass(adbase.ADBase, adapi.ADAPI):
                 is declared without ``start_time`` or ``days``, it will revert to default to the latest
                 history state. When ``end_time`` is specified, it is not possible to declare ``entity_id``.
                 If ``entity_id`` is specified, ``end_time`` will be ignored.
+            callback (callable, optional): If wanting to access the database to get a large amount of data,
+                using a direct call to this function will take a long time to run and lead to AD cancelling the task.
+                To get around this, it is better to pass a function, which will be responsible of receiving the result
+                from the database. The signature of this function follows that of a scheduler call.
             namespace (str, optional): Namespace to use for the call. See the section on
                 `namespaces <APPGUIDE.html#namespaces>`__ for a detailed description.
                 In most cases it is safe to ignore this parameter.
@@ -726,23 +729,24 @@ class Hass(adbase.ADBase, adapi.ADAPI):
             >>> data = self.get_history(end_time = end_time, days = 5)
 
         """
+        
         namespace = self._get_namespace(**kwargs)
+        plugin = await self.AD.plugins.get_plugin_object(namespace)
 
-        if "namespace" in kwargs:
-            del kwargs["namespace"]
+        if hasattr(plugin, "get_history"):
+            callback = kwargs.pop("callback", None)
+            if callback is not None and callable(callback):
+                self.create_task(plugin.get_history(**kwargs), callback)
+                
+            else:
+                return await plugin.get_history(**kwargs)
 
-        if entity_id != "":
-            await self._check_entity(namespace, entity_id)
-        if kwargs == {}:
-            rargs = {"entity_id": entity_id}
         else:
-            rargs = kwargs
-            rargs["entity_id"] = entity_id
-
-        rargs["namespace"] = namespace
-
-        result = await self.call_service("database/history", **rargs)
-        return result
+            self.logger.warning(
+                "Wrong Namespace selected, as %s has no database plugin attached to it",
+                namespace,
+            )
+            return None
 
     @hass_check
     def render_template(self, template, **kwargs):

--- a/appdaemon/plugins/hass/hassapi.py
+++ b/appdaemon/plugins/hass/hassapi.py
@@ -707,7 +707,7 @@ class Hass(adbase.ADBase, adapi.ADAPI):
                 In most cases it is safe to ignore this parameter.
 
         Returns:
-            An iterable list of entity_ids and their history state or task future object if callback supplied.
+            An iterable list of entity_ids and their history state.
 
         Examples:
             Get device state over the last 5 days.
@@ -736,7 +736,7 @@ class Hass(adbase.ADBase, adapi.ADAPI):
         if hasattr(plugin, "get_history"):
             callback = kwargs.pop("callback", None)
             if callback is not None and callable(callback):
-                return await self.create_task(plugin.get_history(**kwargs), callback)
+                self.create_task(plugin.get_history(**kwargs), callback)
 
             else:
                 return await plugin.get_history(**kwargs)

--- a/appdaemon/plugins/hass/hassapi.py
+++ b/appdaemon/plugins/hass/hassapi.py
@@ -729,7 +729,7 @@ class Hass(adbase.ADBase, adapi.ADAPI):
             >>> data = self.get_history(end_time = end_time, days = 5)
 
         """
-        
+
         namespace = self._get_namespace(**kwargs)
         plugin = await self.AD.plugins.get_plugin_object(namespace)
 
@@ -737,14 +737,13 @@ class Hass(adbase.ADBase, adapi.ADAPI):
             callback = kwargs.pop("callback", None)
             if callback is not None and callable(callback):
                 self.create_task(plugin.get_history(**kwargs), callback)
-                
+
             else:
                 return await plugin.get_history(**kwargs)
 
         else:
             self.logger.warning(
-                "Wrong Namespace selected, as %s has no database plugin attached to it",
-                namespace,
+                "Wrong Namespace selected, as %s has no database plugin attached to it", namespace,
             )
             return None
 

--- a/appdaemon/plugins/hass/hassplugin.py
+++ b/appdaemon/plugins/hass/hassplugin.py
@@ -221,8 +221,17 @@ class HassPlugin(PluginBase):
     #
     # async def state(self, entity, attribute, old, new, kwargs):
     #    self.logger.info("State: %s %s %s %s {}".format(kwargs), entity, attribute, old, new)
-    # async def event(self, event, data, kwargs):
-    #    self.logger.info("Event: %s %s {}".format(kwargs), event, data)
+
+    async def event(self, event, data, kwargs):
+        self.logger.debug("Event: %s %s %s", kwargs, event, data)
+
+        if event == "service_registered":  # hass just registered a service
+            domain = data["domain"]
+            service = data["service"]
+            self.AD.services.register_service(
+                self.get_namespace(), domain, service, self.call_plugin_service,
+            )
+
     # async def schedule(self, kwargs):
     #    self.logger.info("Schedule: {}".format(kwargs))
     #
@@ -239,7 +248,9 @@ class HassPlugin(PluginBase):
         # Testing
         #
         # await self.AD.state.add_state_callback(self.name, self.namespace, None, self.state, {})
-        # await self.AD.events.add_event_callback(self.name, self.namespace, self.event, "state_changed")
+
+        # listen for service_registered event
+        await self.AD.events.add_event_callback(self.name, self.namespace, self.event, "service_registered")
         # exec_time = await self.AD.sched.get_now() + datetime.timedelta(seconds=1)
         # await self.AD.sched.insert_schedule(
         #    self.name,
@@ -312,7 +323,7 @@ class HassPlugin(PluginBase):
                 for domain in self.services:
                     for service in domain["services"]:
                         self.AD.services.register_service(
-                            self.get_namespace(), domain["domain"], service, self.call_plugin_service,
+                            self.get_namespace(), domain["domain"], service, self.call_plugin_service, __silent=True
                         )
 
                 # Decide if we can start yet
@@ -351,6 +362,9 @@ class HassPlugin(PluginBase):
             except Exception:
                 self.reading_messages = False
                 self.hass_booting = True
+                # remove callback from getting local events
+                await self.AD.callbacks.clear_callbacks(self.name)
+
                 if not self.already_notified:
                     await self.AD.plugins.notify_plugin_stopped(self.name, self.namespace)
                     self.already_notified = True
@@ -360,6 +374,7 @@ class HassPlugin(PluginBase):
                     self.logger.debug("Unexpected error:")
                     self.logger.debug("-" * 60)
                     self.logger.debug(traceback.format_exc())
+                    print(traceback.format_exc())
                     self.logger.debug("-" * 60)
                     await asyncio.sleep(5)
 
@@ -449,80 +464,18 @@ class HassPlugin(PluginBase):
         else:
             headers = {}
 
-        if domain == "database":
-            if "entity_id" in data and data["entity_id"] != "":
-                filter_entity_id = "?filter_entity_id={}".format(data["entity_id"])
-            else:
-                filter_entity_id = ""
-            start_time = ""
-            end_time = ""
-            if "days" in data:
-                days = data["days"]
-                if days - 1 < 0:
-                    days = 1
-            else:
-                days = 1
-            if "start_time" in data:
-                if isinstance(data["start_time"], str):
-                    start_time = utils.str_to_dt(data["start_time"]).replace(microsecond=0)
-                elif isinstance(data["start_time"], datetime.datetime):
-                    start_time = self.AD.tz.localize(data["start_time"]).replace(microsecond=0)
-                else:
-                    raise ValueError("Invalid type for start time")
-
-            if "end_time" in data:
-                if isinstance(data["end_time"], str):
-                    end_time = utils.str_to_dt(data["end_time"]).replace(microsecond=0)
-                elif isinstance(data["end_time"], datetime.datetime):
-                    end_time = self.AD.tz.localize(data["end_time"]).replace(microsecond=0)
-                else:
-                    raise ValueError("Invalid type for end time")
-
-            # if both are declared, it can't process entity_id
-            if start_time != "" and end_time != "":
-                filter_entity_id = ""
-
-            # if starttime is not declared and entity_id is declared, and days specified
-            elif (filter_entity_id != "" and start_time == "") and "days" in data:
-                start_time = (await self.AD.sched.get_now()).replace(microsecond=0) - datetime.timedelta(days=days)
-
-            # if starttime is declared and entity_id is not declared, and days specified
-            elif filter_entity_id == "" and start_time != "" and end_time == "" and "days" in data:
-                end_time = start_time + datetime.timedelta(days=days)
-
-            # if endtime is declared and entity_id is not declared, and days specified
-            elif filter_entity_id == "" and end_time != "" and start_time == "" and "days" in data:
-                start_time = end_time - datetime.timedelta(days=days)
-
-            if start_time != "":
-                timestamp = "/{}".format(utils.dt_to_str(start_time.replace(microsecond=0), self.AD.tz))
-
-                if filter_entity_id != "":  # if entity_id is specified, end_time cannot be used
-                    end_time = ""
-
-                if end_time != "":
-                    end_time = "?end_time={}".format(
-                        quote(utils.dt_to_str(end_time.replace(microsecond=0), self.AD.tz))
-                    )
-
-            # if no start_time is specified, other parameters are invalid
-            else:
-                timestamp = ""
-                end_time = ""
-
-            api_url = "{}/api/history/period{}{}{}".format(config["ha_url"], timestamp, filter_entity_id, end_time)
-
-        elif domain == "template":
+        if domain == "template":
             api_url = "{}/api/template".format(config["ha_url"])
+        
+        elif domain == "database":
+            return await self.get_history(**data)
 
         else:
             api_url = "{}/api/services/{}/{}".format(config["ha_url"], domain, service)
 
         try:
-            if domain == "database":
-                r = await self.session.get(api_url, headers=headers, verify_ssl=self.cert_verify)
-            else:
-                r = await self.session.post(api_url, headers=headers, json=data, verify_ssl=self.cert_verify)
+
+            r = await self.session.post(api_url, headers=headers, json=data, verify_ssl=self.cert_verify)
 
             if r.status == 200 or r.status == 201:
                 if domain == "template":
@@ -552,6 +505,111 @@ class HassPlugin(PluginBase):
             self.logger.error(traceback.format_exc())
             self.logger.error("-" * 60)
             return None
+    
+    async def get_history(self, **kwargs):
+        """Used to get HA's History"""
+
+        # TODO cert_path is not used
+        if "cert_path" in self.config:
+            cert_path = self.config["cert_path"]
+        else:
+            cert_path = False  # noqa: F841
+
+        if "token" in self.config:
+            headers = {"Authorization": "Bearer {}".format(self.config["token"])}
+        elif "ha_key" in self.config:
+            headers = {"x-ha-access": self.config["ha_key"]}
+        else:
+            headers = {}
+
+        try:
+            if "entity_id" in kwargs and kwargs["entity_id"] != "":
+                filter_entity_id = "?filter_entity_id={}".format(kwargs["entity_id"])
+            else:
+                filter_entity_id = ""
+            start_time = ""
+            end_time = ""
+            if "days" in kwargs:
+                days = kwargs["days"]
+                if days - 1 < 0:
+                    days = 1
+            else:
+                days = 1
+            if "start_time" in kwargs:
+                if isinstance(kwargs["start_time"], str):
+                    start_time = utils.str_to_dt(kwargs["start_time"]).replace(microsecond=0)
+                elif isinstance(kwargs["start_time"], datetime.datetime):
+                    start_time = self.AD.tz.localize(kwargs["start_time"]).replace(microsecond=0)
+                else:
+                    raise ValueError("Invalid type for start time")
+
+            if "end_time" in kwargs:
+                if isinstance(kwargs["end_time"], str):
+                    end_time = utils.str_to_dt(kwargs["end_time"]).replace(microsecond=0)
+                elif isinstance(kwargs["end_time"], datetime.datetime):
+                    end_time = self.AD.tz.localize(kwargs["end_time"]).replace(microsecond=0)
+                else:
+                    raise ValueError("Invalid type for end time")
+
+            # if both are declared, it can't process entity_id
+            if start_time != "" and end_time != "":
+                filter_entity_id = ""
+
+            # if starttime is not declared and entity_id is declared, and days specified
+            elif (filter_entity_id != "" and start_time == "") and "days" in kwargs:
+                start_time = (await self.AD.sched.get_now()).replace(microsecond=0) - datetime.timedelta(days=days)
+
+            # if starttime is declared and entity_id is not declared, and days specified
+            elif filter_entity_id == "" and start_time != "" and end_time == "" and "days" in kwargs:
+                end_time = start_time + datetime.timedelta(days=days)
+
+            # if endtime is declared and entity_id is not declared, and days specified
+            elif filter_entity_id == "" and end_time != "" and start_time == "" and "days" in kwargs:
+                start_time = end_time - datetime.timedelta(days=days)
+
+            if start_time != "":
+                timestamp = "/{}".format(utils.dt_to_str(start_time.replace(microsecond=0), self.AD.tz))
+
+                if filter_entity_id != "":  # if entity_id is specified, end_time cannot be used
+                    end_time = ""
+
+                if end_time != "":
+                    end_time = "?end_time={}".format(
+                        quote(utils.dt_to_str(end_time.replace(microsecond=0), self.AD.tz))
+                    )
+
+            # if no start_time is specified, other parameters are invalid
+            else:
+                timestamp = ""
+                end_time = ""
+
+            api_url = "{}/api/history/period{}{}{}".format(self.config["ha_url"], timestamp, filter_entity_id, end_time)
+
+            r = await self.session.get(api_url, headers=headers, verify_ssl=self.cert_verify)
+
+            if r.status == 200 or r.status == 201:
+                result = await r.json()
+            else:
+                self.logger.warning(
+                    "Error calling Home Assistant to get_history"
+                    )
+                txt = await r.text()
+                self.logger.warning("Code: %s, error: %s", r.status, txt)
+                result = None
+
+            return result
+        
+        except aiohttp.client_exceptions.ServerDisconnectedError:
+            self.logger.warning("HASS Disconnected unexpectedly during get_history()")
+
+        except Exception:
+            self.logger.error("-" * 60)
+            self.logger.error("Unexpected error during get_history")
+            self.logger.error("-" * 60)
+            self.logger.error(traceback.format_exc())
+            self.logger.error("-" * 60)
+            
+        return None 
 
     async def get_hass_state(self, entity_id=None):
 

--- a/docs/HISTORY.rst
+++ b/docs/HISTORY.rst
@@ -47,6 +47,7 @@ Change Log
 **Breaking Changes**
 
 - Changed ``websocket_connected`` and ``websocket_disconnected`` events to ``stream_connected`` and ``stream_disconnected`` respectively
+- Changed the `get_history` api, as `entity_id` has been removed from the api
 
 None
 

--- a/docs/HISTORY.rst
+++ b/docs/HISTORY.rst
@@ -31,6 +31,7 @@ Change Log
 - Cleanup sequences when modified. This ensures removed sequences are also removed from the Admin UI and AD
 - Added support to use environment variables using the `!env_var` tag, if not wanting to use the `!secrets` tag
 - Additional format for time travel start and end times accepted
+- Added the ability to specify a callback to hass get_history. This way,  large amount of data can be retrieved from the database, without AD cancelling the task
 
 **Fixes**
 

--- a/docs/HISTORY.rst
+++ b/docs/HISTORY.rst
@@ -31,7 +31,6 @@ Change Log
 - Cleanup sequences when modified. This ensures removed sequences are also removed from the Admin UI and AD
 - Added support to use environment variables using the `!env_var` tag, if not wanting to use the `!secrets` tag
 - Additional format for time travel start and end times accepted
-- Moved `appdaemon` services to `admin` namespace
 
 **Fixes**
 
@@ -47,7 +46,6 @@ Change Log
 **Breaking Changes**
 
 - Changed ``websocket_connected`` and ``websocket_disconnected`` events to ``stream_connected`` and ``stream_disconnected`` respectively
-- Moved `appdaemon` based services to function within the `admin` namespace. So services for apps and logs will not function within `admin` and not `appdaemon`
 
 None
 


### PR DESCRIPTION
This PR allows to specify a callback to be used with get_history database call.  This can be very useful when retrieving large amount of data, so a callback can be specified to pickup the data.

Also it uses the same signature for the AD `get_history`, allowing it to be moved to AD api over time.

This adds the ability to listen to new service calls, so that PR will need to added before adding this PR.

Regards 