### PR TITLE
Fix documentation unit for sleep delay parameter

### DIFF
--- a/appdaemon/adapi.py
+++ b/appdaemon/adapi.py
@@ -2784,7 +2784,7 @@ class ADAPI:
         (not available in sync apps)
 
         Args:
-            delay (int): Number of seconds to pause.
+            delay (float): Number of seconds to pause.
             result (optional): Result to return upon delay completion.
 
         Returns:


### PR DESCRIPTION
Documentation states that unit is int, but user can also pass in fractions to sleep for less than a second.