### PR TITLE
feat(app_mgmt): ignore apps starting with a dot

### DIFF
--- a/appdaemon/app_management.py
+++ b/appdaemon/app_management.py
@@ -355,6 +355,13 @@ class AppManagement:
                                             # We don't care what it looks like just pass it through
                                             #
                                             valid_apps[app] = config[app]
+                                        elif app.startswith("."):
+                                            #
+                                            # We ignore any configuration starting with a dot.
+                                            # This could be useful to not comment everything
+                                            # and ignore common code when using YAML anchors.
+                                            #
+                                            pass
                                         elif (
                                             isinstance(config[app], dict)
                                             and "class" in config[app]

--- a/appdaemon/app_management.py
+++ b/appdaemon/app_management.py
@@ -355,9 +355,9 @@ class AppManagement:
                                             # We don't care what it looks like just pass it through
                                             #
                                             valid_apps[app] = config[app]
-                                        elif app.startswith("."):
+                                        elif "." in app:
                                             #
-                                            # We ignore any configuration starting with a dot.
+                                            # We ignore any app containing a dot.
                                             # This could be useful to not comment everything
                                             # and ignore common code when using YAML anchors.
                                             #


### PR DESCRIPTION
This PR solves #1003. This ignores any app configuration starting with a dot, this has two use cases:
- If a user wants to ignore an application, they can just add a dot at the beginning instead of commenting each line of the YAML config
- Allows ignoring base code configuration when using YAML anchors feature. See more in detail in #1003.