### PR TITLE
Widget: clickable icon

### DIFF
--- a/appdaemon/widgets/baseclickableicon/baseclickableicon.css
+++ b/appdaemon/widgets/baseclickableicon/baseclickableicon.css
@@ -1,0 +1,32 @@
+.widget-baseclickableicon-{{id}} .title {
+	position: absolute;
+	top: 5px;
+	width: 100%;
+}
+
+.widget-baseclickableicon-{{id}} .title2 {
+	position: absolute;
+	top: 23px;
+	width: 100%;
+}
+
+.widget-baseclickableicon-{{id}} .state_text {
+	position: absolute;
+	bottom: -3px;
+	width: 100%;
+}
+
+.widget-baseclickableicon-{{id}} .icon {
+	position: absolute;
+	top: 43px;
+	width: 100%;
+}
+
+.widget-baseclickableicon-{{id}} .toggle-area {
+	z-index: 10;
+	position: absolute;
+	top: 0;
+	left: 0;
+	width: 100%;
+	height: 100%;
+}

--- a/appdaemon/widgets/baseclickableicon/baseclickableicon.html
+++ b/appdaemon/widgets/baseclickableicon/baseclickableicon.html
@@ -1,0 +1,4 @@
+<h1 class="title" data-bind="text: title, attr:{style: title_style}"></h1>
+<h1 class="title2" data-bind="text: title2, attr:{style: title2_style}"></h1>
+<h2 class="icon" data-bind="attr:{style: icon_style}"><i data-bind="attr: {class: icon}"></i></h2>
+<h1 class="state_text" data-bind="text: state_text, attr: {style: state_text_style}"></h1>

--- a/appdaemon/widgets/baseclickableicon/baseclickableicon.js
+++ b/appdaemon/widgets/baseclickableicon/baseclickableicon.js
@@ -1,0 +1,111 @@
+function baseclickableicon(widget_id, url, skin, parameters)
+{
+    // Will be using "self" throughout for the various flavors of "this"
+    // so for consistency ...
+
+    self = this;
+
+    // Initialization
+
+    self.widget_id = widget_id;
+
+    // Parameters may come in useful later on
+
+    self.parameters = parameters;
+
+    self.OnStateAvailable = OnStateAvailable;
+    self.OnStateUpdate = OnStateUpdate;
+    self.OnIconClick = OnIconClick;
+
+    var monitored_entities =
+        [
+            {"entity": parameters.entity, "initial": self.OnStateAvailable, "update": self.OnStateUpdate}
+        ];
+
+    if ("post_service" in self.parameters) {console.log("widget id je " + widget_id);
+        var callbacks =
+            [
+                {"selector": '#' + widget_id, "action": "click", "callback": self.OnIconClick},
+            ]
+    } else {
+        var callbacks = []
+    }
+
+    // Finally, call the parent constructor to get things moving
+
+    WidgetBase.call(self, widget_id, url, skin, parameters, monitored_entities, callbacks);
+
+    // Function Definitions
+
+    // The StateAvailable function will be called when
+    // self.state[<entity>] has valid information for the requested entity
+    // state is the initial state
+
+    function OnStateAvailable(self, state)
+    {
+        self.state = state.state;
+        set_view(self, self.state)
+    }
+
+    // The OnStateUpdate function will be called when the specific entity
+    // receives a state update - its new values will be available
+    // in self.state[<entity>] and returned in the state parameter
+
+    function OnStateUpdate(self, state)
+    {
+        self.state = state.state;
+
+        delay_time = self.parameters.update_delay;
+        if (delay_time != undefined) {
+            if (self.timeout != undefined) {
+                clearTimeout(self.timeout);
+            }
+    
+            self.timeout = setTimeout(() => set_view(self, self.state), delay_time * 1000);
+        } else {
+            set_view(self, self.state);
+        }
+
+        
+    }
+
+    function OnIconClick(self)
+    {
+        args = self.parameters.post_service;
+        args["namespace"] = self.parameters.namespace;
+
+        self.call_service(self, args);
+    }
+
+    // Set view is a helper function to set all aspects of the widget to its
+    // current state - it is called by widget code when an update occurs
+    // or some other event that requires a an update of the view
+
+    function set_view(self, state, level)
+    {
+        if ("icons" in self.parameters)
+        {
+            if (state in self.parameters.icons)
+            {
+                self.set_icon(self, "icon", self.parameters.icons[state].icon);
+                self.set_field(self, "icon_style", self.parameters.icons[state].style)
+            }
+            else if ("default" in self.parameters.icons)
+            {
+                self.set_icon(self, "icon", self.parameters.icons.default.icon);
+                self.set_field(self, "icon_style", self.parameters.icons.default.style)
+            }
+            else
+            {
+                self.set_icon(self, "icon", "fa-circle-thin");
+                self.set_field(self, "icon_style", "color: white")
+            }
+
+        }
+
+        if ("state_text" in self.parameters && self.parameters.state_text == 1)
+        {
+            self.set_field(self, "state_text", self.map_state(self, state))
+        }
+    }
+}

--- a/appdaemon/widgets/clickable_icon.yaml
+++ b/appdaemon/widgets/clickable_icon.yaml
@@ -1,0 +1,19 @@
+widget_type: baseclickableicon
+entity: "{{entity}}"
+post_service:
+  service: homeassistant/turn_on
+  entity_id: "{{script_entity}}"
+fields:
+  title: "{{title}}"
+  title2: "{{title2}}"
+  icon: ""
+  icon_style: ""
+  state_text: ""
+icons: []
+static_icons: []
+css: []
+static_css:
+  title_style: $icon_title_style
+  title2_style: $icon_title2_style
+  state_text_style: $icon_state_text_style
+  widget_style: $icon_widget_style


### PR DESCRIPTION
This widget combines existing widgets: _icon_ and _script_. It shows an icon same as the _icon_ widget and adds the ability to run a HA script on click which should perform desired actions possibly driven by a state of another entity (usually the one monitored by the icon).
Another feature added to this widget is a possibility of adding update delay - when set, it delays state update by the specified amount of seconds (useful when it takes some time to update secondary states by HA - in that case, this can prevent blinking of the icon).

Usage example:
```
ac_control:
    widget_type: clickable_icon
    entity: sensor.ac_db_control_option
    script_entity: script.toggle_ac
    icons:
        "turn_on_temporarily":
            icon: mdi-air-conditioner
        "turn_on":
            icon: mdi-air-conditioner
        "turn_off":
            icon: mdi-air-conditioner
            style: "color: aquamarine;"
    state_text: 1
    state_map:
        "turn_on_temporarily": Turn on AC temporarily
        "turn_on": Turn on AC
        "turn_off": Turn off AC
```