### PR TITLE
Icon widget extension: service calls, state update delay

### DIFF
--- a/appdaemon/widgets/baseicon/baseicon.js
+++ b/appdaemon/widgets/baseicon/baseicon.js
@@ -63,8 +63,8 @@ function baseicon(widget_id, url, skin, parameters)
     }
 
     function OnIconClick(self) {
-        if (self.post_service !== undefined) {
-            self.call_service(self, self.post_service);
+        if (self.post_service_active !== undefined) {
+            self.call_service(self, self.post_service_active);
         }
     }
 
@@ -104,13 +104,13 @@ function baseicon(widget_id, url, skin, parameters)
     }
 
     function set_service_call(self, data) {
-        if (data.service_call !== undefined) {
-            self.post_service = data.service_call;
-            if (self.post_service["namespace"] === undefined) {
-                self.post_service["namespace"] = self.parameters.namespace;
+        if (data.post_service_active !== undefined) {
+            self.post_service_active = data.post_service_active;
+            if (self.post_service_active["namespace"] === undefined) {
+                self.post_service_active["namespace"] = self.parameters.namespace;
             }
         } else {
-            self.post_service = undefined;
+            self.post_service_active = undefined;
         }
     }
 }

--- a/appdaemon/widgets/baseicon/baseicon.js
+++ b/appdaemon/widgets/baseicon/baseicon.js
@@ -51,8 +51,8 @@ function baseicon(widget_id, url, skin, parameters)
         self.state = state.state;
 
         delay_time = self.parameters.update_delay;
-        if (delay_time != undefined) {
-            if (self.timeout != undefined) {
+        if (delay_time !== undefined) {
+            if (self.timeout !== undefined) {
                 clearTimeout(self.timeout);
             }
 
@@ -63,7 +63,7 @@ function baseicon(widget_id, url, skin, parameters)
     }
 
     function OnIconClick(self) {
-        if (self.post_service != undefined) {
+        if (self.post_service !== undefined) {
             self.call_service(self, self.post_service);
         }
     }
@@ -104,18 +104,18 @@ function baseicon(widget_id, url, skin, parameters)
     }
 
     function set_service_call(self, data) {
-        if (data.service != undefined) {
+        if (data.service !== undefined) {
             self.post_service = data.service;
-            if (self.post_service["namespace"] == undefined) {
+            if (self.post_service["namespace"] === undefined) {
                 self.post_service["namespace"] = self.parameters.namespace;
-            };
-        } else if (data.sequence != undefined) {
+            }
+        } else if (data.sequence !== undefined) {
             self.post_service = {
                 service: "sequence/run",
                 sequence: "sequence." + data.sequence,
                 namespace: "rules"
             }
-        } else if (data.script != undefined) {
+        } else if (data.script !== undefined) {
             self.post_service = {
                 service: "homeassistant/turn_on",
                 entity_id: "script." + data.script,

--- a/appdaemon/widgets/baseicon/baseicon.js
+++ b/appdaemon/widgets/baseicon/baseicon.js
@@ -112,7 +112,7 @@ function baseicon(widget_id, url, skin, parameters)
         } else if (data.sequence !== undefined) {
             self.post_service = {
                 service: "sequence/run",
-                sequence: "sequence." + data.sequence,
+                entity_id: "sequence." + data.sequence,
                 namespace: "rules"
             }
         } else if (data.script !== undefined) {

--- a/appdaemon/widgets/baseicon/baseicon.js
+++ b/appdaemon/widgets/baseicon/baseicon.js
@@ -109,10 +109,10 @@ function baseicon(widget_id, url, skin, parameters)
     function set_service_call(self, data) {
         if (data.sequence != undefined) {
             self.post_service = data.sequence;
-        } else if (data.script_entity != undefined) {
+        } else if (data.script != undefined) {
             self.post_service = {
                 service: "homeassistant/turn_on",
-                entity_id: data.script_entity
+                entity_id: data.script
             }
         } else {
             self.post_service = undefined;

--- a/appdaemon/widgets/baseicon/baseicon.js
+++ b/appdaemon/widgets/baseicon/baseicon.js
@@ -22,9 +22,9 @@ function baseicon(widget_id, url, skin, parameters)
             {"entity": parameters.entity, "initial": self.OnStateAvailable, "update": self.OnStateUpdate}
         ];
 
-        var callbacks = [
-            {"selector": '#' + widget_id, "action": "click", "callback": self.OnIconClick},
-        ]
+    var callbacks = [
+        {"selector": '#' + widget_id, "action": "click", "callback": self.OnIconClick},
+    ]
 
     // Finally, call the parent constructor to get things moving
 
@@ -55,7 +55,7 @@ function baseicon(widget_id, url, skin, parameters)
             if (self.timeout != undefined) {
                 clearTimeout(self.timeout);
             }
-    
+
             self.timeout = setTimeout(() => set_view(self, self.state), delay_time * 1000);
         } else {
             set_view(self, self.state);
@@ -104,13 +104,17 @@ function baseicon(widget_id, url, skin, parameters)
     }
 
     function set_service_call(self, data) {
-        if (data.sequence != undefined) {
+        if (data.service != undefined) {
+            self.post_service = data.service;
+            if (self.post_service["namespace"] == undefined) {
+                self.post_service["namespace"] = self.parameters.namespace;
+            }
+        } else if (data.sequence != undefined) {
             self.post_service = {
                 service: "sequence/run",
                 sequence: data.sequence,
                 namespace: "rules"
             }
-            self.post_service = data.sequence;
         } else if (data.script != undefined) {
             self.post_service = {
                 service: "homeassistant/turn_on",

--- a/appdaemon/widgets/baseicon/baseicon.js
+++ b/appdaemon/widgets/baseicon/baseicon.js
@@ -64,10 +64,7 @@ function baseicon(widget_id, url, skin, parameters)
 
     function OnIconClick(self) {
         if (self.post_service != undefined) {
-            args = self.post_service;
-            args["namespace"] = self.parameters.namespace;
-
-            self.call_service(self, args);
+            self.call_service(self, self.post_service);
         }
     }
 
@@ -108,11 +105,17 @@ function baseicon(widget_id, url, skin, parameters)
 
     function set_service_call(self, data) {
         if (data.sequence != undefined) {
+            self.post_service = {
+                service: "sequence/run",
+                sequence: data.sequence,
+                namespace: "rules"
+            }
             self.post_service = data.sequence;
         } else if (data.script != undefined) {
             self.post_service = {
                 service: "homeassistant/turn_on",
-                entity_id: data.script
+                entity_id: data.script,
+                namespace: self.parameters.namespace
             }
         } else {
             self.post_service = undefined;

--- a/appdaemon/widgets/baseicon/baseicon.js
+++ b/appdaemon/widgets/baseicon/baseicon.js
@@ -108,17 +108,17 @@ function baseicon(widget_id, url, skin, parameters)
             self.post_service = data.service;
             if (self.post_service["namespace"] == undefined) {
                 self.post_service["namespace"] = self.parameters.namespace;
-            }
+            };
         } else if (data.sequence != undefined) {
             self.post_service = {
                 service: "sequence/run",
-                sequence: data.sequence,
+                sequence: "sequence." + data.sequence,
                 namespace: "rules"
             }
         } else if (data.script != undefined) {
             self.post_service = {
                 service: "homeassistant/turn_on",
-                entity_id: data.script,
+                entity_id: "script." + data.script,
                 namespace: self.parameters.namespace
             }
         } else {

--- a/appdaemon/widgets/baseicon/baseicon.js
+++ b/appdaemon/widgets/baseicon/baseicon.js
@@ -13,15 +13,18 @@ function baseicon(widget_id, url, skin, parameters)
 
     self.parameters = parameters;
 
-    var callbacks = [];
-
     self.OnStateAvailable = OnStateAvailable;
     self.OnStateUpdate = OnStateUpdate;
+    self.OnIconClick = OnIconClick;
 
     var monitored_entities =
         [
             {"entity": parameters.entity, "initial": self.OnStateAvailable, "update": self.OnStateUpdate}
         ];
+
+        var callbacks = [
+            {"selector": '#' + widget_id, "action": "click", "callback": self.OnIconClick},
+        ]
 
     // Finally, call the parent constructor to get things moving
 
@@ -46,7 +49,26 @@ function baseicon(widget_id, url, skin, parameters)
     function OnStateUpdate(self, state)
     {
         self.state = state.state;
-        set_view(self, self.state)
+
+        delay_time = self.parameters.update_delay;
+        if (delay_time != undefined) {
+            if (self.timeout != undefined) {
+                clearTimeout(self.timeout);
+            }
+    
+            self.timeout = setTimeout(() => set_view(self, self.state), delay_time * 1000);
+        } else {
+            set_view(self, self.state);
+        }
+    }
+
+    function OnIconClick(self) {
+        if (self.post_service != undefined) {
+            args = self.post_service;
+            args["namespace"] = self.parameters.namespace;
+
+            self.call_service(self, args);
+        }
     }
 
     // Set view is a helper function to set all aspects of the widget to its
@@ -60,17 +82,20 @@ function baseicon(widget_id, url, skin, parameters)
             if (state in self.parameters.icons)
             {
                 self.set_icon(self, "icon", self.parameters.icons[state].icon);
-                self.set_field(self, "icon_style", self.parameters.icons[state].style)
+                self.set_field(self, "icon_style", self.parameters.icons[state].style);
+                set_service_call(self, self.parameters.icons[state]);
             }
             else if ("default" in self.parameters.icons)
             {
                 self.set_icon(self, "icon", self.parameters.icons.default.icon);
-                self.set_field(self, "icon_style", self.parameters.icons.default.style)
+                self.set_field(self, "icon_style", self.parameters.icons.default.style);
+                set_service_call(self, self.parameters.default);
             }
             else
             {
                 self.set_icon(self, "icon", "fa-circle-thin");
-                self.set_field(self, "icon_style", "color: white")
+                self.set_field(self, "icon_style", "color: white");
+                self.post_service = undefined;
             }
 
         }
@@ -78,6 +103,19 @@ function baseicon(widget_id, url, skin, parameters)
         if ("state_text" in self.parameters && self.parameters.state_text == 1)
         {
             self.set_field(self, "state_text", self.map_state(self, state))
+        }
+    }
+
+    function set_service_call(self, data) {
+        if (data.sequence != undefined) {
+            self.post_service = data.sequence;
+        } else if (data.script_entity != undefined) {
+            self.post_service = {
+                service: "homeassistant/turn_on",
+                entity_id: data.script_entity
+            }
+        } else {
+            self.post_service = undefined;
         }
     }
 }

--- a/appdaemon/widgets/baseicon/baseicon.js
+++ b/appdaemon/widgets/baseicon/baseicon.js
@@ -104,22 +104,10 @@ function baseicon(widget_id, url, skin, parameters)
     }
 
     function set_service_call(self, data) {
-        if (data.service !== undefined) {
-            self.post_service = data.service;
+        if (data.service_call !== undefined) {
+            self.post_service = data.service_call;
             if (self.post_service["namespace"] === undefined) {
                 self.post_service["namespace"] = self.parameters.namespace;
-            }
-        } else if (data.sequence !== undefined) {
-            self.post_service = {
-                service: "sequence/run",
-                entity_id: "sequence." + data.sequence,
-                namespace: "rules"
-            }
-        } else if (data.script !== undefined) {
-            self.post_service = {
-                service: "homeassistant/turn_on",
-                entity_id: "script." + data.script,
-                namespace: self.parameters.namespace
             }
         } else {
             self.post_service = undefined;

--- a/appdaemon/widgets/baseicon/baseicon.js
+++ b/appdaemon/widgets/baseicon/baseicon.js
@@ -92,7 +92,7 @@ function baseicon(widget_id, url, skin, parameters)
             {
                 self.set_icon(self, "icon", "fa-circle-thin");
                 self.set_field(self, "icon_style", "color: white");
-                self.post_service = undefined;
+                set_service_call(self, {});
             }
 
         }

--- a/docs/DASHBOARD_CREATION.rst
+++ b/docs/DASHBOARD_CREATION.rst
@@ -1083,13 +1083,13 @@ A widget to monitor the state of an entity and display a different icon and styl
        "active":
          icon: fas-glass
          style: "color: green"
-         service_call:
+         post_service_active:
            service: homeassistant/turn_on
            entity_id: script.deactivate
        "inactive":
          icon: fas-repeat
          style: "color: blue"
-         service_call:
+         post_service_active:
            service: homeassistant/turn_on
            entity_id: script.activate
        "idle":

--- a/docs/DASHBOARD_CREATION.rst
+++ b/docs/DASHBOARD_CREATION.rst
@@ -1101,7 +1101,7 @@ A widget to monitor the state of an entity and display a different icon and styl
 
 The icons list is mandatory, and each entry must contain both an icon and a style entry. It is recommended that quotes are used around the state names, as without these, YAML will translate states like ``on``  and ``off`` to ``true`` and ``false``.
 
-Each icon can have a service call assigned - on icon click, specified service like HA script or AD sequence is called.
+Each icon can have a service call assigned by post_service_active entry - on icon click, specified service like HA script or AD sequence is called for currently active state.
 
 The default entry icon and style will be used if the state doesn't match any in the list - meaning that it is not necessary to define all states if only 1 or 2 actually matter.
 

--- a/docs/DASHBOARD_CREATION.rst
+++ b/docs/DASHBOARD_CREATION.rst
@@ -1083,9 +1083,15 @@ A widget to monitor the state of an entity and display a different icon and styl
        "active":
          icon: fas-glass
          style: "color: green"
+         service_call:
+           service: homeassistant/turn_on
+           entity_id: script.deactivate
        "inactive":
          icon: fas-repeat
          style: "color: blue"
+         service_call:
+           service: homeassistant/turn_on
+           entity_id: script.activate
        "idle":
          icon: fas-frown
          style: "color: red"
@@ -1093,7 +1099,9 @@ A widget to monitor the state of an entity and display a different icon and styl
          icon: fas-rocket
          style: "color: cyan"
 
-The icons list is mandatory, and each entry must contain both an icon and a style entry. It is recommended that quotes are used around the state names, as without these, YAML will translate states like ``on``  and ``off`` to ``true`` and ``false``
+The icons list is mandatory, and each entry must contain both an icon and a style entry. It is recommended that quotes are used around the state names, as without these, YAML will translate states like ``on``  and ``off`` to ``true`` and ``false``.
+
+Each icon can have a service call assigned - on icon click, specified service like HA script or AD sequence is called.
 
 The default entry icon and style will be used if the state doesn't match any in the list - meaning that it is not necessary to define all states if only 1 or 2 actually matter.
 
@@ -1101,7 +1109,7 @@ Mandatory arguments:
 ^^^^^^^^^^^^^^^^^^^
 
 -  ``entity`` - the entity\_id of the binary\_sensor
--  ``icons`` - a list of icons and styles to be applied for various states.
+-  ``icons`` - a list of icons, styles and service calls to be applied for various states
 
 Optional Arguments:
 ^^^^^^^^^^^^^^^^^^^
@@ -1110,6 +1118,7 @@ Optional Arguments:
 -  ``title2`` - a second line of title text
 -  ``state_text``
 -  ``state_map``
+-  ``update_delay`` - seconds to wait before processing state update
 
 Style Arguments:
 ^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
This extends the functionality of _icon_ widget by the ability to make service calls and adding delay to react to state update.
Service calls are possible by using _post_service_active_ parameter for each state. On icon click, specified service is run.
State update delay is specified by _update_delay_ parameter which is in seconds. If specified, on monitored entity state update, rerendering of the icon is delayed by a specified amount of seconds. This is useful when the monitored entity state takes some time to change properly and icon blinks briefly.

Usage example:
```
ac_control:
    widget_type: icon
    entity: sensor.ac_db_control_option
    icons:
        "turn_on_temporarily":
            post_service_active:
                service: sequence/run
                entity_id: sequence.ac_on_temporarily
            icon: mdi-air-conditioner
        "turn_on":
            post_service_active:
                service: homeassistant/turn_on
                entity_id: script.turn_on_ac
            icon: mdi-air-conditioner
        "turn_off":
            post_service_active:
                service: homeassistant/turn_on
                entity_id: script.turn_off_ac
            icon: mdi-air-conditioner
            style: "color: aquamarine;"
    state_text: 1
    update_delay: 1
    state_map:
        "turn_on_temporarily": Turn AC on temporarily
        "turn_on": Turn AC on
        "turn_off": Turn AC off
```