### PR TITLE
Upgrade astral to 2.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-astral==1.10.1
+astral==2.2
 pytz==2019.3
 requests>=2.22.0
 websocket-client==0.57.0


### PR DESCRIPTION
Summary:
Version 2 removed location and instead uses a combination of `LocationInfo` and `sun` to calculate the next sunrise/sunset, so we need to switch to the new API to properly get sunrise/sunset.

Test plan:
Verified that calculating sunrise/sunset works the same way as v1 by just playing with python cli
launched appdaemon and made sure everything starts up