### PR TITLE
Alarm panel - "✖️" close button icon

### DIFF
--- a/appdaemon/widgets/basealarm/basealarm.html
+++ b/appdaemon/widgets/basealarm/basealarm.html
@@ -4,7 +4,7 @@
 <h2 class="value" data-bind="text: state, attr:{ style: state_style}"></h2>
 <div id="Dialog" class="modalDialog">
 <div data-bind="attr:{style: panel_background_style}">
-<h2 id="close" class="modalDialogCloseButton">X</h2>
+<h2 id="close" class="modalDialogCloseButton">&times;</h2>
 <h2 class="panel-state" data-bind="text: state, attr:{style: panel_state_style}"></h2>
 <h2 class="panel-state" data-bind="text: code, attr:{style: panel_code_style}"></h2>
 <div class="container">


### PR DESCRIPTION
In the base alarm modal panel, changes the icon from "X" to a slightly more appealing "✖️".