### PR TITLE
Add support for installing user-specified system packages with docker run

### DIFF
--- a/dockerStart.sh
+++ b/dockerStart.sh
@@ -42,6 +42,9 @@ if [ -n "$DASH_URL" ]; then
   fi
 fi
 
+#install user-specific packages
+apk add --no-cache $(find $CONF -name system_packages.txt | xargs cat | tr '\n' ' ')
+
 #check recursively under CONF for additional python dependencies defined in requirements.txt
 find $CONF -name requirements.txt -exec pip3 install --upgrade -r {} \;
 

--- a/docs/DOCKER_TUTORIAL.rst
+++ b/docs/DOCKER_TUTORIAL.rst
@@ -281,3 +281,5 @@ Adding Dependencies
 -------------------
 
 Sometimes it can be helpful to install additional Python dependencies into the Docker container before AppDaemon starts, to allow additional libraries to be used from Apps. The Docker script will recursively search the CONF directory for any files named ``requirements.txt``. All the found requirements will be used as input to pip3 to install any packages that they describe.
+
+It's also often helpful to add system packages to the Docker container before AppDaemon starts, to allow any custom python packages that depend on other `system packages <https://pkgs.alpinelinux.org/packages>`_ to install without issue. The Docker script will recursively search the CONF directory for any files named ``system_packages.txt``. Packages should be listed either space delimited or newline delimited. These packages will be used as input to ``apk add`` to install any packages that they describe.


### PR DESCRIPTION
Just added something simple. I was encountering some issues where python packages specified in `requirements.txt` were missing system-level dependencies (e.g., `zlib`, `libjpeg`) and wanted to add this in so I could specify custom packages that were required to ensure the `pip3 install` command succeeded.

Let me know if I need to make any tweaks - first time trying to contribute to this repo.