### PR TITLE
Fix config file name

### DIFF
--- a/appdaemon/__main__.py
+++ b/appdaemon/__main__.py
@@ -372,19 +372,19 @@ class ADMain:
         exit = False
 
         if "time_zone" not in config["appdaemon"]:
-            self.logger.error("time_zone not specified in appdaemon.cfg")
+            self.logger.error("time_zone not specified in appdaemon.yaml")
             exit = True
 
         if "latitude" not in config["appdaemon"]:
-            self.logger.error("latitude not specified in appdaemon.cfg")
+            self.logger.error("latitude not specified in appdaemon.yaml")
             exit = True
 
         if "longitude" not in config["appdaemon"]:
-            self.logger.error("longitude not specified in appdaemon.cfg")
+            self.logger.error("longitude not specified in appdaemon.yaml")
             exit = True
 
         if "elevation" not in config["appdaemon"]:
-            self.logger.error("elevation not specified in appdaemon.cfg")
+            self.logger.error("elevation not specified in appdaemon.yaml")
             exit = True
 
         if exit is True:

--- a/docs/INSTALL.rst
+++ b/docs/INSTALL.rst
@@ -96,7 +96,7 @@ AppDaemon arguments
       -d, --daemon          run as a background process
 
 -c is the path to the configuration directory. If not specified,
-AppDaemon will look for a file named ``appdaemon.cfg`` first in
+AppDaemon will look for a file named ``appdaemon.yaml`` first in
 ``~/.homeassistant`` then in ``/etc/appdaemon``. If the directory is not
 specified and it is not found in either location, AppDaemon will raise
 an exception. In addition, AppDaemon expects to find a dir named


### PR DESCRIPTION
The configuration file is called `appdaemon.yaml`. There were some references to `appdaemon.cfg` which I removed.