### PR TITLE
Add multiarch build

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,29 +7,29 @@ jobs:
     steps:
     - name: Docker meta
       id: docker_meta
-      uses: crazy-max/ghaction-docker-meta@v1
+      uses: crazy-max/ghaction-docker-meta@v1.11.0
       with:
         images: ghcr.io/lexfrei/appdaemon/appdaemon
         tag-sha: true
 
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v1
+      uses: docker/setup-qemu-action@v1.0.1
 
     - name: Checkout
-      uses: actions/checkout@v2.3.2
+      uses: actions/checkout@v2.3.4
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
+      uses: docker/setup-buildx-action@v1.1.1
 
     - name: Login to GitHub Container Registry
-      uses: docker/login-action@v1
+      uses: docker/login-action@v1.8.0
       with:
         registry: ghcr.io
         username: ${{ github.repository_owner }}
         password: ${{ secrets.CR_PAT }}
 
     - name: Build and push
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v2.2.2
       with:
         context: .
         file: ./Dockerfile

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -32,7 +32,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: .
-        file: ./build/exporter/Dockerfile
+        file: ./Dockerfile
         platforms: linux/amd64,linux/arm64
         push: true
         tags: ${{ steps.docker_meta.outputs.tags }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,38 @@
+name: Build Container Image
+
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Docker meta
+      id: docker_meta
+      uses: crazy-max/ghaction-docker-meta@v1
+      with:
+        images: ghcr.io/lexfrei/gow/ow-exporter
+        tag-sha: true
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v1
+
+    - name: Checkout
+      uses: actions/checkout@v2.3.2
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v1
+      with:
+        registry: ghcr.io
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.CR_PAT }}
+
+    - name: Build and push
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        file: ./build/exporter/Dockerfile
+        platforms: linux/amd64,linux/arm64
+        push: true
+        tags: ${{ steps.docker_meta.outputs.tags }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,7 +9,7 @@ jobs:
       id: docker_meta
       uses: crazy-max/ghaction-docker-meta@v1.11.0
       with:
-        images: ghcr.io/lexfrei/appdaemon/appdaemon
+        images: ghcr.io/AppDaemon/appdaemon/appdaemon
         tag-sha: true
 
     - name: Set up QEMU

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,7 +9,7 @@ jobs:
       id: docker_meta
       uses: crazy-max/ghaction-docker-meta@v1
       with:
-        images: ghcr.io/lexfrei/gow/ow-exporter
+        images: ghcr.io/lexfrei/appdaemon/appdaemon
         tag-sha: true
 
     - name: Set up QEMU

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -33,6 +33,6 @@ jobs:
       with:
         context: .
         file: ./Dockerfile
-        platforms: linux/amd64,linux/arm64
+        platforms: linux/arm/v7,linux/arm/v6,linux/amd64,linux/arm64
         push: true
         tags: ${{ steps.docker_meta.outputs.tags }}


### PR DESCRIPTION
Important! Add CR_PAT (container registry personal access token) to repo secrets. Required permissions: packages:*

- Building on each push. Add the desired config, example: https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#on
- Current tagging: commit sha and branch name (ex.: sha-8a83892, dev)
- Change image repository to the desired one at L:12
- GitHub Container registry used. Feel free to change it on L:27
- ARM64/AMD64 build enabled. Add more on L:36
