### PR TITLE
Docs - Better Callback Documentation

### DIFF
--- a/docs/AD_API_REFERENCE.rst
+++ b/docs/AD_API_REFERENCE.rst
@@ -264,6 +264,37 @@ WebRoute
 .. autofunction:: appdaemon.adapi.ADAPI.register_route
 .. autofunction:: appdaemon.adapi.ADAPI.unregister_route
 
+Callback Signatures
+~~~~~~~~~
+
+This section summarizes the key callback signatures for easy reference. See the links below for complete descriptions.
+
+**State Callback**
+
+
+.. code:: python
+
+      def my_callback(self, entity, attribute, old, new, kwargs):
+        <do some useful work here>
+`Full documentation <APPGUIDE.html#state-callbacks>`__
+
+
+**Scheduler Callback**
+
+.. code:: python
+
+      def my_callback(self, kwargs):
+        <do some useful work here>
+`Full documentation <APPGUIDE.html#about-schedule-callbacks>`__        
+
+**Event Callback**
+
+.. code:: python
+
+      def my_callback(self, event_name, data, kwargs):
+        <do some useful work here>
+`Full documentation <APPGUIDE.html#about-event-callbacks>`__        
+
 Other
 ~~~~~
 


### PR DESCRIPTION
Created a Callback Signature section of AD AD_API_REFERENCE

In learning to use AD I found myself constantly jumping back and forth
to the callback signatures for events / states / scheduler.  

The current process is quite cumbersome:

1. Goto AD API 
2. Open Reference
3. Go to your main area (state, scheduler, event)
4. Scroll to the listen event
5. Click to where the callback is defined in the guide.

This would have made my life much easier!

BTW - Perhaps a better way to solve this would be to have the full
documentation here in the API page. Maybe you could write the
single source of truth in the code and reference it both 
in the API doc and the Guide. But I didn't want to do a bunch
of work only to have it be wrong.