### PR TITLE
fixed mqttapi.listen_event()

### DIFF
--- a/appdaemon/plugins/mqtt/mqttapi.py
+++ b/appdaemon/plugins/mqtt/mqttapi.py
@@ -146,7 +146,7 @@ class Mqtt(adbase.ADBase, adapi.ADAPI):
                 )
                 return
 
-        return super(Mqtt, self).listen_event(callback, event, **kwargs)
+        return await super(Mqtt, self).listen_event(callback, event, **kwargs)
 
     #
     # service calls


### PR DESCRIPTION
mqttapi.listen_event() was incorrectly returning a Task,
not the return value.

changed:
    return super()
to
    return await super()