### PR TITLE
python3.9 compatibility, #1064

### DIFF
--- a/appdaemon/__main__.py
+++ b/appdaemon/__main__.py
@@ -130,7 +130,11 @@ class ADMain:
 
             self.logger.debug("Start Main Loop")
 
-            pending = asyncio.Task.all_tasks()
+            try:
+                pending = asyncio.Task.all_tasks()
+            except AttributeError:
+                pending = asyncio.all_tasks(loop)
+
             loop.run_until_complete(asyncio.gather(*pending))
 
             #


### PR DESCRIPTION
* fixes the deprecated `all_tasks` call
* not save for 3.10 as of now (passing `loop` will be deprecated)
* not passing `loop` leads to an error as the internally called `get_loop` fails for some reason
* **warning** this likely will break all python <=3.9 versions