### PR TITLE
Fix Docker builds on Raspberry Pi

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM python:3.8-alpine
+ARG IMAGE=3.8-alpine
+FROM python:${IMAGE}
 
 # Environment vars we can configure against
 # But these are optional, so we won't define them now

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-ARG IMAGE=3.8-alpine
-FROM python:${IMAGE}
+ARG IMAGE=python:3.8-alpine
+FROM ${IMAGE}
 
 # Environment vars we can configure against
 # But these are optional, so we won't define them now

--- a/docs/INSTALL.rst
+++ b/docs/INSTALL.rst
@@ -208,7 +208,7 @@ prior to installing AppDaemon with the pip3 method:
 Raspberry Pi Docker
 -------------------
 
-Since the official Docker image isn't compatible with raspberry Pi, you will need to build your own docker image
+Since the official Docker image isn't compatible with Raspberry Pi, you will need to build your own docker image
 from the downloaded repository.
 
 .. code:: bash
@@ -220,7 +220,7 @@ You can then build and run the docker image locally as follows:
 
 .. code:: bash
 
-    $ docker build -t appdaemon --network=host .
+    $ docker build -t appdaemon --build-arg IMAGE=3.8-alpine3.12 --network=host .
     $ docker run --name=appdaemon -d -p 5050:5050 \
       --restart=always \
       -e HA_URL="<Your HA_URL value>" \

--- a/docs/INSTALL.rst
+++ b/docs/INSTALL.rst
@@ -220,7 +220,7 @@ You can then build and run the docker image locally as follows:
 
 .. code:: bash
 
-    $ docker build -t appdaemon --build-arg IMAGE=3.8-alpine3.12 --network=host .
+    $ docker build -t appdaemon --build-arg IMAGE=python:3.8-alpine3.12 --network=host .
     $ docker run --name=appdaemon -d -p 5050:5050 \
       --restart=always \
       -e HA_URL="<Your HA_URL value>" \


### PR DESCRIPTION
## Summary

Docker build on Raspberry Pi is failing on Alpine 3.13:
```
Step 7/11 : RUN apk add tzdata
 ---> Running in ec28ac240ffc
fetch https://dl-cdn.alpinelinux.org/alpine/v3.13/main/armv7/APKINDEX.tar.gz
ERROR: https://dl-cdn.alpinelinux.org/alpine/v3.13/main: temporary error (try again later)
WARNING: Ignoring https://dl-cdn.alpinelinux.org/alpine/v3.13/main: No such file or directory
fetch https://dl-cdn.alpinelinux.org/alpine/v3.13/community/armv7/APKINDEX.tar.gz
ERROR: https://dl-cdn.alpinelinux.org/alpine/v3.13/community: temporary error (try again later)
WARNING: Ignoring https://dl-cdn.alpinelinux.org/alpine/v3.13/community: No such file or directory
ERROR: unable to select packages:
  tzdata (no such package):
    required by: world[tzdata]
The command '/bin/sh -c apk add tzdata' returned a non-zero code: 1
```

While I thought it was related to network settings or container permissions, it turned out to be an effect of alpinelinux/docker-alpine#135.

From the Alpine 3.13 [release notes](https://wiki.alpinelinux.org/wiki/Release_Notes_for_Alpine_3.13.0#time64_requirements):
> Alpine Linux 3.13.0 requires the host Docker to be version 19.03.9 (which contains backported moby commit 89fabf0) or greater and the host libseccomp to be version 2.4.2 (which contains backported libseccomp commit bf747eb) or greater

On Raspbian buster, libseccomp is at 2.3.3-4. I'm not sure if there are prebuilt packages available for `>=2.4.2` but that would be another option for resolving this.

### Approach

This PR adds a build argument for image name and defaults it to what it was, and updates docs for Raspberry Pi docker build to use a currently-working Alpine version.

### Feedback

- [x] Should image name argument include the entire image name, not just something under the python namespace?

P.S. thank you for your work on this! I have not even had a chance to run it yet but am excited to try it! 🎉 
