### PR TITLE
Update docker to use python:3.8-slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,10 +14,14 @@ EXPOSE 5050
 VOLUME /conf
 VOLUME /certs
 
-# Copy appdaemon into image
 WORKDIR /usr/src/app
-COPY . .
 
+# Install dependencies
+ADD ./requirements.txt ./requirements.txt
+RUN pip install -r requirements.txt --no-cache-dir
+
+# Add appdaemon to image
+ADD . .
 RUN pip install --no-cache-dir .
 
 # Start script

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-alpine
+FROM python:3.8-slim
 
 # Environment vars we can configure against
 # But these are optional, so we won't define them now
@@ -18,14 +18,7 @@ VOLUME /certs
 WORKDIR /usr/src/app
 COPY . .
 
-# Install timezone data
-RUN apk add tzdata
-
-# Install dependencies
-RUN apk add --no-cache build-base gcc libffi-dev openssl-dev musl-dev cargo \
-    && pip install --no-cache-dir .
-# Install additional packages
-RUN apk add --no-cache curl
+RUN pip install --no-cache-dir .
 
 # Start script
 RUN chmod +x /usr/src/app/dockerStart.sh

--- a/dockerStart.sh
+++ b/dockerStart.sh
@@ -63,7 +63,7 @@ if [ -n "$ELEVATION" ]; then
 fi
 
 #install user-specific packages
-apk add --no-cache $(find $CONF -name system_packages.txt | xargs cat | tr '\n' ' ')
+apt install $(find $CONF -name system_packages.txt | xargs cat | tr '\n' ' ')
 #check recursively under CONF for additional python dependencies defined in requirements.txt
 find $CONF -name requirements.txt -exec pip3 install --upgrade -r {} \;
 


### PR DESCRIPTION
Results in a smaller image and much faster build.

![image](https://user-images.githubusercontent.com/2578772/108621576-1f7bd100-743c-11eb-8d71-62fb483f80ac.png)

#1171 #1073