### PR TITLE
Listen_state fix

### DIFF
--- a/appdaemon/scheduler.py
+++ b/appdaemon/scheduler.py
@@ -114,6 +114,11 @@ class Scheduler:
                 #
                 # it's a "duration" entry
                 #
+
+                # first remove the duration parameter
+                if args["kwargs"].get("__duration"):
+                    del args["kwargs"]["__duration"]
+
                 executed = await self.AD.threading.dispatch_worker(
                     name,
                     {

--- a/appdaemon/scheduler.py
+++ b/appdaemon/scheduler.py
@@ -94,10 +94,11 @@ class Scheduler:
     async def cancel_timer(self, name, handle):
         executed = False
         self.logger.debug("Canceling timer for %s", name)
-        if name in self.schedule and handle in self.schedule[name]:
+        if self.check_handle(name, handle):
             del self.schedule[name][handle]
             await self.AD.state.remove_entity("admin", "scheduler_callback.{}".format(handle))
             executed = True
+
         if name in self.schedule and self.schedule[name] == {}:
             del self.schedule[name]
 
@@ -105,6 +106,13 @@ class Scheduler:
             self.logger.warning("Invalid callback handle '{}' in cancel_timer() from app {}".format(handle, name))
 
         return executed
+    
+    def check_handle(self, name, handle):
+        """Check if the handler is valid"""
+        if name in self.schedule and handle in self.schedule[name]:
+            return True
+        
+        return False
 
     # noinspection PyBroadException
     async def exec_schedule(self, name, args, uuid_):
@@ -598,7 +606,7 @@ class Scheduler:
         return self.next_sunrise() < self.next_sunset()
 
     async def info_timer(self, handle, name):
-        if name in self.schedule and handle in self.schedule[name]:
+        if self.check_handle(name,  handle):
             callback = self.schedule[name][handle]
             return (
                 self.make_naive(callback["timestamp"]),

--- a/appdaemon/scheduler.py
+++ b/appdaemon/scheduler.py
@@ -106,12 +106,12 @@ class Scheduler:
             self.logger.warning("Invalid callback handle '{}' in cancel_timer() from app {}".format(handle, name))
 
         return executed
-    
+
     def check_handle(self, name, handle):
         """Check if the handler is valid"""
         if name in self.schedule and handle in self.schedule[name]:
             return True
-        
+
         return False
 
     # noinspection PyBroadException
@@ -606,7 +606,7 @@ class Scheduler:
         return self.next_sunrise() < self.next_sunset()
 
     async def info_timer(self, handle, name):
-        if self.check_handle(name,  handle):
+        if self.check_handle(name, handle):
             callback = self.schedule[name][handle]
             return (
                 self.make_naive(callback["timestamp"]),

--- a/appdaemon/state.py
+++ b/appdaemon/state.py
@@ -197,7 +197,7 @@ class State:
             # In the case of a quick_start parameter,
             # start the clock immediately if the device is already in the new state
             #
-            if "immediate" in kwargs and kwargs["immediate"] is True:
+            if kwargs.get("immediate") is True:
                 __duration = 0  # run it immediately
                 __new_state = None
                 __attribute = None
@@ -229,14 +229,14 @@ class State:
                                 __new_state = self.state[namespace][entity]
 
                     if "duration" in kwargs:
-                        __duration = kwargs["duration"]
+                        __duration = int(kwargs["duration"])
                 if run:
-                    exec_time = await self.AD.sched.get_now() + datetime.timedelta(seconds=int(__duration))
+                    exec_time = await self.AD.sched.get_now() + datetime.timedelta(seconds=__duration)
 
                     if kwargs.get("oneshot", False):
                         kwargs["__handle"] = handle
 
-                    kwargs["__duration"] = await self.AD.sched.insert_schedule(
+                    __scheduler_handle = await self.AD.sched.insert_schedule(
                         name,
                         exec_time,
                         cb,
@@ -248,6 +248,9 @@ class State:
                         __new_state=__new_state,
                         **kwargs,
                     )
+
+                    if __duration >= 1:  # it only stores it when needed
+                        kwargs["__duration"] = __scheduler_handle
 
             await self.AD.state.add_entity(
                 "admin",

--- a/appdaemon/state.py
+++ b/appdaemon/state.py
@@ -249,7 +249,7 @@ class State:
                         **kwargs,
                     )
 
-                    if __duration >= 1: # it only stores it when needed
+                    if __duration >= 1:  # it only stores it when needed
                         kwargs["__duration"] = __scheduler_handle
 
             await self.AD.state.add_entity(

--- a/appdaemon/state.py
+++ b/appdaemon/state.py
@@ -249,7 +249,7 @@ class State:
                         **kwargs,
                     )
 
-                    if __duration >= 1:  # it only stores it when needed
+                    if __duration >= 1: # it only stores it when needed
                         kwargs["__duration"] = __scheduler_handle
 
             await self.AD.state.add_entity(

--- a/appdaemon/threading.py
+++ b/appdaemon/threading.py
@@ -653,7 +653,9 @@ class Threading:
                     # Or we won't if they are not.
                     # Either way, we cancel the old timer
                     #
-                    await self.AD.sched.cancel_timer(name, kwargs["__duration"])
+                    if self.AD.sched.check_handle(name, kwargs["__duration"]):
+                        await self.AD.sched.cancel_timer(name, kwargs["__duration"])
+
                     del kwargs["__duration"]
 
                 #

--- a/appdaemon/threading.py
+++ b/appdaemon/threading.py
@@ -654,6 +654,7 @@ class Threading:
                     # Either way, we cancel the old timer
                     #
                     await self.AD.sched.cancel_timer(name, kwargs["__duration"])
+                    del kwargs["__duration"]
 
                 #
                 # Check if we care about the change


### PR DESCRIPTION
This issue fixes a situation whereby if `listen_state` is used with the `immediate` flag, the user's log gets filled with `cancel_timer` warnings.