### PR TITLE
Terminated apps

### DIFF
--- a/appdaemon/app_management.py
+++ b/appdaemon/app_management.py
@@ -211,7 +211,7 @@ class AppManagement:
                     self.logger.warning(
                         "Logged an error to %s", self.AD.logging.get_filename("error_log"),
                     )
-                
+
                 executed = False
 
         if delete:
@@ -220,7 +220,7 @@ class AppManagement:
 
             if name in self.global_module_dependencies:
                 del self.global_module_dependencies[name]
-        
+
         else:
             self.objects[name]["running"] = False
 
@@ -241,7 +241,7 @@ class AppManagement:
 
         if self.AD.http is not None:
             await self.AD.http.terminate_app(name)
-        
+
         return executed
 
     async def start_app(self, app):
@@ -272,7 +272,7 @@ class AppManagement:
             error_logger.warning("-" * 60)
             if self.AD.logging.separate_error_log() is True:
                 self.logger.warning("Logged an error to %s", self.AD.logging.get_filename("error_log"))
-        
+
         return executed
 
     async def restart_app(self, app):
@@ -332,7 +332,7 @@ class AppManagement:
                     "id": uuid.uuid4().hex,
                     "pin_app": self.AD.threading.app_should_be_pinned(name),
                     "pin_thread": pin,
-                    "running": True
+                    "running": True,
                 }
 
                 # load the module path into app entity
@@ -353,7 +353,7 @@ class AppManagement:
             "id": uuid.uuid4().hex,
             "pin_app": False,
             "pin_thread": -1,
-            "running": False
+            "running": False,
         }
 
     async def read_config(self):  # noqa: C901
@@ -946,8 +946,8 @@ class AppManagement:
                     apps["init"][app] = 1
 
         # Terminate apps
-        
-        apps_terminated = {} # store apps properly terminated is any
+
+        apps_terminated = {}  # store apps properly terminated is any
         if apps is not None and apps["term"]:
             prio_apps = self.get_app_deps_and_prios(apps["term"], mode)
 
@@ -991,9 +991,9 @@ class AppManagement:
                         await self.set_state(app, state="disabled")
                         await self.increase_inactive_apps(app)
                     else:
-                        if apps_terminated.get(app, True) is True: # the app terminated properly
+                        if apps_terminated.get(app, True) is True:  # the app terminated properly
                             await self.init_object(app)
-                        
+
                         else:
                             self.logger.warning("Cannot initialize app %s, as it didn't terminate properly", app)
 
@@ -1017,9 +1017,9 @@ class AppManagement:
                 if "disable" in self.app_config[app] and self.app_config[app]["disable"] is True:
                     pass
                 else:
-                    if apps_terminated.get(app, True) is True: # the app terminated properly
+                    if apps_terminated.get(app, True) is True:  # the app terminated properly
                         await self.initialize_app(app)
-                    
+
                     else:
                         self.logger.debug("Cannot initialize app %s, as it didn't terminate properly", app)
 

--- a/docs/APPGUIDE.rst
+++ b/docs/APPGUIDE.rst
@@ -208,7 +208,10 @@ module, it will automatically reload and recompile the module. It will
 also figure out which Apps were using that Module and restart them,
 causing their ``terminate()`` functions to be called if they exist, all
 of their existing callbacks to be cleared, and their ``initialize()``
-function to be called.
+function to be called. It should be noted that if a terminate function exists,
+and while executing it AD encounters an error, the app will not be auto reloaded.
+The app will only be reloaded, when next the app's file has been changed, presumably
+to fix the issue.
 
 The same is true if changes are made to an App's configuration -
 changing the class, or arguments (see later) will cause that App to be

--- a/docs/HISTORY.rst
+++ b/docs/HISTORY.rst
@@ -26,6 +26,7 @@ Change Log
 
 **Fixes**
 
+- FIxed issue whereby when a non properly terminated app has an error,  AD starts the app automatically
 - Fixed issue whereby it is possible to use the app api to "start" an already running app
 - Fixed issue whereby when app api is used, AD could hook itself since it gets into a loop depending on how the app is written
 - Fixed `get_history_api` for HASS - contributed by `Ross Rosen <https://github.com/rr326>`__


### PR DESCRIPTION
This fixes this issue #1117, whereby when an app doesn't terminate properly, AD still initializes it.

This PR prevents that from happening