### PR TITLE
App ensure future

### DIFF
--- a/appdaemon/app_management.py
+++ b/appdaemon/app_management.py
@@ -1373,16 +1373,16 @@ class AppManagement:
             return None
 
         if service == "start":
-            asyncio.create_task(self.start_app(app))
+            asyncio.ensure_future(self.start_app(app))
 
         elif service == "stop":
-            asyncio.create_task(self.stop_app(app, delete=False))
+            asyncio.ensure_future(self.stop_app(app, delete=False))
 
         elif service == "restart":
-            asyncio.create_task(self.restart_app(app))
+            asyncio.ensure_future(self.restart_app(app))
 
         elif service == "reload":
-            asyncio.create_task(self.check_app_updates(mode="init"))
+            asyncio.ensure_future(self.check_app_updates(mode="init"))
 
         elif service in ["create", "edit", "remove", "enable", "disable"]:
             # first the check app updates needs to be stopped if on

--- a/appdaemon/app_management.py
+++ b/appdaemon/app_management.py
@@ -214,7 +214,7 @@ class AppManagement:
 
             if name in self.global_module_dependencies:
                 del self.global_module_dependencies[name]
-        
+
         else:
             self.objects[name]["running"] = False
 
@@ -321,7 +321,7 @@ class AppManagement:
                     "id": uuid.uuid4().hex,
                     "pin_app": self.AD.threading.app_should_be_pinned(name),
                     "pin_thread": pin,
-                    "running": True
+                    "running": True,
                 }
 
                 # load the module path into app entity
@@ -342,7 +342,7 @@ class AppManagement:
             "id": uuid.uuid4().hex,
             "pin_app": False,
             "pin_thread": -1,
-            "running": False
+            "running": False,
         }
 
     async def read_config(self):  # noqa: C901

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,4 +26,4 @@ azure-keyvault-secrets==4.2.0
 azure-storage-blob==12.7.1
 pygments==2.6.1
 sockjs==0.10.0
-uvloop==0.15.2; sys_platform != 'win32'
+uvloop==0.14.0; sys_platform != 'win32'

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,4 +26,4 @@ azure-keyvault-secrets==4.2.0
 azure-storage-blob==12.7.1
 pygments==2.6.1
 sockjs==0.10.0
-uvloop==0.14.0; sys_platform != 'win32'
+uvloop==0.15.2; sys_platform != 'win32'


### PR DESCRIPTION
This allows for `ensure_future` to be used rather than `create_task` to allow for python 3.6 compatibility 