### PR TITLE
Enable mouse events

### DIFF
--- a/appdaemon/assets/javascript/dashboard.js
+++ b/appdaemon/assets/javascript/dashboard.js
@@ -416,7 +416,7 @@ var WidgetBase = function(widget_id, url, skin, parameters, monitored_entities, 
 
             }
 
-            else 
+            else
             {
                 $(callbacks[i].selector).on(callbacks[i].action, (
                     function (callback, ch, params) {

--- a/appdaemon/assets/javascript/dashboard.js
+++ b/appdaemon/assets/javascript/dashboard.js
@@ -406,13 +406,26 @@ var WidgetBase = function(widget_id, url, skin, parameters, monitored_entities, 
     {
         if ("selector" in callbacks[i])
         {
-            $(callbacks[i].selector).on(callbacks[i].action, (
-                function (callback, ch, params) {
-                    return function () {
-                        callback(ch, params)
-                    };
-                }(callbacks[i].callback, child, callbacks[i].parameters))
-            );
+            if ("event" in callbacks[i] && callbacks[i].event === true)
+            {
+
+                var data = {};
+                data.parameters = callbacks[i].parameters;
+
+                $(callbacks[i].selector).on(callbacks[i].action, data, callbacks[i].callback);
+
+            }
+
+            else 
+            {
+                $(callbacks[i].selector).on(callbacks[i].action, (
+                    function (callback, ch, params) {
+                        return function () {
+                            callback(ch, params)
+                        };
+                    }(callbacks[i].callback, child, callbacks[i].parameters))
+                );
+            }
         }
         else if ("observable" in callbacks[i])
         {

--- a/appdaemon/assets/javascript/dashboard.js
+++ b/appdaemon/assets/javascript/dashboard.js
@@ -406,7 +406,7 @@ var WidgetBase = function(widget_id, url, skin, parameters, monitored_entities, 
     {
         if ("selector" in callbacks[i])
         {
-            if ("event" in callbacks[i] && callbacks[i].event === true)
+            if ("DOMEventData" in callbacks[i] && callbacks[i].DOMEventData === true)
             {
 
                 var data = {};

--- a/docs/HISTORY.rst
+++ b/docs/HISTORY.rst
@@ -6,6 +6,7 @@ Change Log
 
 **Features**
 
+- Added the ability to allow widget to make use of mouse events, which can then be sent to AD backend
 - Added the ability to add custom javascript code to dashboard - contributed by `Rene Tode <https://github.com/ReneTode>`__
 - Added the ability to set `deviceId` on dashboard, via the dashboard URL - contributed by `clyra <https://github.com/clyra>`__
 - Added the ability to navigate to different dashboards on different devices based on the set `deviceId` - contributed by `clyra <https://github.com/clyra>`__

--- a/docs/WIDGETDEV.rst
+++ b/docs/WIDGETDEV.rst
@@ -535,6 +535,25 @@ The next step is to set up the widget to respond to various events such as butto
                 {"selector": '#' + widget_id + ' #level-down', "action": "click", "callback": self.OnLowerLevelClick},
             ]
 
+
+There could be occasions when it is desirable to register for an event other than just "click", and get the whole event data.
+This is possible by registering and passing "event" and boolen `true`, so that dashboard is aware of the fact the entire
+event data is required. Below is an example 
+
+.. code:: javascript
+
+            // Define callbacks for some mouse events
+            // They are defined as functions below and can be any name as long as the
+            // 'self'variables match the callbacks array below
+            // We need to add them into the object for later reference
+    
+            self.OnMouseEvent = OnMouseEvent
+    
+            var callbacks =
+                [
+                    {"selector": '#' + widget_id + ' > span', "action": ["mousedown", "mouseup"], "event": true, "callback": self.OnMouseEvent}
+                ]
+
 Each widget has the opportunity to register itself for button clicks or touches, or any other event type such as ``change``.
 This is done by filling out the callbacks array (which is later used to initialize them).
 Here we are registering 3 callbacks.

--- a/docs/WIDGETDEV.rst
+++ b/docs/WIDGETDEV.rst
@@ -536,8 +536,8 @@ The next step is to set up the widget to respond to various events such as butto
             ]
 
 
-There could be occasions when it is desirable to register for an event other than just "click", and get the whole event data.
-This is possible by registering and passing "event" and boolen `true`, so that dashboard is aware of the fact the entire
+There could be occasions when it is desirable to register for an event, and get the whole event data.
+This is possible by registering and passing "DOMEventData" and boolen `true`, so that dashboard is aware of the fact the entire
 event data is required. Below is an example
 
 .. code:: javascript
@@ -551,7 +551,7 @@ event data is required. Below is an example
 
             var callbacks =
                 [
-                    {"selector": '#' + widget_id + ' > span', "action": ["mousedown", "mouseup"], "event": true, "callback": self.OnMouseEvent}
+                    {"selector": '#' + widget_id + ' > span', "action": ["mousedown", "mouseup"], "DOMEventData": true, "callback": self.OnMouseEvent}
                 ]
 
 Each widget has the opportunity to register itself for button clicks or touches, or any other event type such as ``change``.

--- a/docs/WIDGETDEV.rst
+++ b/docs/WIDGETDEV.rst
@@ -538,7 +538,7 @@ The next step is to set up the widget to respond to various events such as butto
 
 There could be occasions when it is desirable to register for an event other than just "click", and get the whole event data.
 This is possible by registering and passing "event" and boolen `true`, so that dashboard is aware of the fact the entire
-event data is required. Below is an example 
+event data is required. Below is an example
 
 .. code:: javascript
 
@@ -546,9 +546,9 @@ event data is required. Below is an example
             // They are defined as functions below and can be any name as long as the
             // 'self'variables match the callbacks array below
             // We need to add them into the object for later reference
-    
+
             self.OnMouseEvent = OnMouseEvent
-    
+
             var callbacks =
                 [
                     {"selector": '#' + widget_id + ' > span', "action": ["mousedown", "mouseup"], "event": true, "callback": self.OnMouseEvent}


### PR DESCRIPTION
This PR allows for sending to AD backend standard events like mouse events from a widget. This allows for registering and making use of the standard jquery callback and get the entire event data, which can then be processed and sent to AD as needed. This way, not being limited to only the data based by dashboard.