### PR TITLE
Dashstream addListener

### DIFF
--- a/appdaemon/assets/javascript/dashboard.js
+++ b/appdaemon/assets/javascript/dashboard.js
@@ -94,7 +94,7 @@ var DashStream = function(transport, protocol, domain, port, title, widgets)
         console.log("Generic message", data)
     };
 
-    this.on_disconnect = function(data)
+    this.on_disconnect = function()
     {
         // now check if there are registered callbacks and run them
         if (self.dashEvents.onDisconnect.length > 0) {
@@ -106,7 +106,7 @@ var DashStream = function(transport, protocol, domain, port, title, widgets)
                 if (!callback) continue;
 
                 try {
-                    callback(data);
+                    callback();
 
                 } catch (e) {
                     console.error("An Error", e , " occured when when executing onDisconnecr for ", name);

--- a/appdaemon/assets/javascript/stream.js
+++ b/appdaemon/assets/javascript/stream.js
@@ -58,7 +58,7 @@ var Stream = function(transport, protocol, domain, port, client_name, on_connect
 
     this.ad_on_disconnect = function()
     {
-        // do nothing
+        self.on_disconnect();
     };
 
     this.send = function(request, callback)

--- a/docs/HISTORY.rst
+++ b/docs/HISTORY.rst
@@ -7,6 +7,7 @@ Change Log
 **Features**
 
 - Added new api `timer_running`, to be used to confirm if a previously scheduled timer is still running
+- Added the ability for custom scripts to listen for dashstream events
 
 **Fixes**
 


### PR DESCRIPTION
This PR allow for custom dashboard scripts to register for dashstream events like `onConnect` and `onDisconnect`.

To register for when it connects simply 

```
dashstream.addListener("onConnect", "script1", function(data) {
     // do stuff when it connects
})
```

To register for when it disconnects simply 

```
dashstream.addListener("onDisconnect", "script1", function() {
     // do stuff when it disconnects
})
```