### PR TITLE
auto setting return to the navigate widget

### DIFF
--- a/appdaemon/widgets/basejavascript/basejavascript.js
+++ b/appdaemon/widgets/basejavascript/basejavascript.js
@@ -134,7 +134,29 @@ function basejavascript(widget_id, url, skin, parameters)
                 i++
             }
         }
-
+        else
+        {
+            if ("timeout" in parameters)
+            {
+                try {
+                    current_dash = location.pathname.split('/')[1];
+                    if (i == 0)
+                    {
+                        url = url + "?return=" + current_dash;
+                        i++
+                    }
+                    else
+                    {
+                        url = url + "&return=" + current_dash;
+                        i++
+                    }
+                }
+                catch
+                {
+                    console.log('not a dashboard?')
+                }
+            }
+        }
         if ("timeout" in parameters)
         {
             if (i == 0)

--- a/docs/DASHBOARD_CREATION.rst
+++ b/docs/DASHBOARD_CREATION.rst
@@ -1746,7 +1746,7 @@ parameter, args have the following meaning:
 -  ``return`` - dashboard to return to after the timeout has elapsed.
 -  ``sticky`` - whether or not to return to the original dashboard after it has been clicked on. The default behavior (``sticky=0``) is to remain on the new dashboard if clicked and return to the original otherwise. With ``sticky=1```, clicking the dashboard will extend the amount of time, but it will return to the original dashboard after a period of inactivity equal to ``timeout``.
 
-Both ``timeout`` and ``return`` must be specified.
+If ``timeout`` is specified but ``return`` not, then the widget will use the current dashboard as the return target.
 
 If adding arguments, use the args variable. Do not append them to the URL
 or you may break skinning. Add arguments like this:


### PR DESCRIPTION
When using the timeout feature of navigate widget you also have to set the return parameter. This PR modifies the navigate widget to auto-fill the return parameter to the current dashboard if timeout is set. So, if you have a "go to panel3" navigate widget, you can use it from panel1 or panel2 and the dashboard will return to the "calling" panel after the timeout. 