### PR TITLE
Fix persistent namespace

### DIFF
--- a/appdaemon/state.py
+++ b/appdaemon/state.py
@@ -93,10 +93,14 @@ class State:
         """Used to add a database file for a created namespace"""
 
         try:
+            if namespace in self.state and isinstance(self.state[namespace], utils.PersistentDict):
+                self.logger.info("Persistent Namespace '%s' already initialized", namespace)
+                return
+
             nspath = os.path.join(self.AD.config_dir, "namespaces")
             safe = bool(writeback == "safe")
-
             nspath_file = os.path.join(nspath, f"{namespace}.db")
+
             self.state[namespace] = utils.PersistentDict(nspath_file, safe)
 
             self.logger.info("Persistent Namespace '%s' initialized", namespace)

--- a/docs/HISTORY.rst
+++ b/docs/HISTORY.rst
@@ -10,6 +10,7 @@ Change Log
 
 **Fixes**
 
+- Fixed issue with when a plugin that is persistent re-initializes, and it creates an error
 - Bumped azure-mgmt-compute from 19.0.0 to 20.0.0
 - Bumped deepdiff from 5.2.3 to 5.3.0
 - Bumped wheel from 0.34.2 to 0.36.2


### PR DESCRIPTION
Fixes issue with when a plugin that is set to persist its entities re-initializes, it creates an error in the logs, because the namespace was already created that was persistent. 