### PR TITLE
Add Semaphore CI to auto-build multiple docker architecture

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -1,0 +1,43 @@
+version: v1.0
+
+name: Build and deploy Pipeline
+agent:
+  machine:
+    type: e1-standard-2
+    os_image: ubuntu1804
+execution_time_limit:
+  hours: 3
+
+global_job_config:
+
+  prologue:
+    commands:
+      - echo $DOCKER_TOKEN | docker login --username "$DOCKER_USERNAME" --password-stdin
+
+  env_vars:
+    - name: DOCKER_USERNAME
+      value: sineverba
+    - name: DOCKER_IMAGE
+      value: appdaemon
+
+blocks:
+  - name: 'Build and deploy'
+    run:
+      when: "tag =~ '.*'"
+    task:
+      jobs:
+        - name: 'Build and deploy'
+          commands:
+            - checkout
+            - docker -v
+            - mkdir -vp ~/.docker/cli-plugins/
+            - curl --silent -L "https://github.com/docker/buildx/releases/download/v0.5.1/buildx-v0.5.1.linux-amd64" > ~/.docker/cli-plugins/docker-buildx
+            - chmod a+x ~/.docker/cli-plugins/docker-buildx
+            - docker buildx version
+            - docker run --rm --privileged tonistiigi/binfmt:latest --install all
+            - docker buildx ls
+            - docker buildx create --name multiarch --driver docker-container --use
+            - docker buildx inspect --bootstrap --builder multiarch
+            - docker buildx build --platform linux/arm64/v8,linux/amd64,linux/arm/v6,linux/arm/v7 --tag $DOCKER_USERNAME/$DOCKER_IMAGE:$SEMAPHORE_GIT_TAG_NAME --tag $DOCKER_USERNAME/$DOCKER_IMAGE:latest --push .
+      secrets:
+        - name: DOCKER_TOKEN

--- a/README.md
+++ b/README.md
@@ -10,6 +10,17 @@ suitable for wall mounted tablets.
 
 For full instructions on installation and use check out the [AppDaemon Project Documentation](http://appdaemon.readthedocs.io).
 
+## Build image for multiple architectures
+
+`$ make multiple`
+
+## Github / image tags and versions
+
+| Github / Docker Image tag | AppDaemon version | Architectures |
+| ------------------------- | ----------------- | ------------- |
+| latest | 4.0.8 | linux/arm64/v8,linux/amd64,linux/arm/v6,linux/arm/v7 |
+| 4.0.8 | 4.0.8 | linux/arm64/v8,linux/amd64,linux/arm/v6,linux/arm/v7 |
+
 
 ## Development of the AppDaemon library
 


### PR DESCRIPTION
Hi to all,
this is a contribution to auto-generate multiple docker images for multiple architectures.
Uses the support of Semaphore CI and automatically build images when a new tag is created.

Of course, needs an account on Semaphore CI and edit the `.semaphore/semaphore.yml` file with right data (that need to be placed as secrets on Semaphore CI itself).

It seems working (can you see it on my Dockerhub space): [https://hub.docker.com/r/sineverba/appdaemon](https://hub.docker.com/r/sineverba/appdaemon)

Thank you all and have a nice day!