### PR TITLE
Deregister app services

### DIFF
--- a/appdaemon/adapi.py
+++ b/appdaemon/adapi.py
@@ -5,6 +5,7 @@ import iso8601
 import re
 from datetime import timedelta
 from copy import deepcopy
+from typing import Any, Optional
 
 # needed for fake coro cb that looks like scheduler
 import uuid
@@ -1534,11 +1535,11 @@ class ADAPI:
     #
 
     @staticmethod
-    def _check_service(service):
+    def _check_service(service: str) -> None:
         if service.find("/") == -1:
             raise ValueError("Invalid Service Name: {}".format(service))
 
-    def register_service(self, service, cb, **kwargs):
+    def register_service(self, service: str, cb: Any, **kwargs: Optional[dict]) -> None:
         """Registers a service that can be called from other apps, the REST API and the Event Stream
 
         Using this function, an App can register a function to be available in the service registry.
@@ -1575,7 +1576,7 @@ class ADAPI:
 
         self.AD.services.register_service(namespace, d, s, cb, __async="auto", **kwargs)
 
-    def deregister_service(self, service, **kwargs):
+    def deregister_service(self, service: str, **kwargs: Optional[dict]) -> bool:
         """Deregisters a service that had been previously registered
 
         Using this function, an App can deregister a service call, it has initially registered in the service registry.
@@ -1610,7 +1611,7 @@ class ADAPI:
 
         return self.AD.services.deregister_service(namespace, d, s, **kwargs)
 
-    def list_services(self, **kwargs):
+    def list_services(self, **kwargs: Optional[dict]) -> list:
         """List all services available within AD
 
         Using this function, an App can request all available services within AD
@@ -1643,7 +1644,7 @@ class ADAPI:
         return self.AD.services.list_services(namespace)  # retrieve services
 
     @utils.sync_wrapper
-    async def call_service(self, service, **kwargs):
+    async def call_service(self, service: str, **kwargs: Optional[dict]) -> Any:
         """Calls a Service within AppDaemon.
 
         This function can call any service and provide any required parameters.

--- a/appdaemon/adapi.py
+++ b/appdaemon/adapi.py
@@ -5,7 +5,7 @@ import iso8601
 import re
 from datetime import timedelta
 from copy import deepcopy
-from typing import Any, Optional
+from typing import Any, Optional, Callable
 
 # needed for fake coro cb that looks like scheduler
 import uuid
@@ -1539,7 +1539,9 @@ class ADAPI:
         if service.find("/") == -1:
             raise ValueError("Invalid Service Name: {}".format(service))
 
-    def register_service(self, service: str, cb: Any, **kwargs: Optional[dict]) -> None:
+    def register_service(
+        self, service: str, cb: Callable[[str, str, str, dict], Any], **kwargs: Optional[dict]
+    ) -> None:
         """Registers a service that can be called from other apps, the REST API and the Event Stream
 
         Using this function, an App can register a function to be available in the service registry.

--- a/appdaemon/adapi.py
+++ b/appdaemon/adapi.py
@@ -1550,6 +1550,10 @@ class ADAPI:
             cb: A reference to the function to be called when the service is requested. This function may be a regular
                 function, or it may be async. Note that if it is an async function, it will run on AppDaemon's main loop
                 meaning that any issues with the service could result in a delay of AppDaemon's core functions.
+        Keyword Args:
+            namespace(str, optional): Namespace to use for the call. See the section on
+                `namespaces <APPGUIDE.html#namespaces>`__ for a detailed description.
+                In most cases, it is safe to ignore this parameter.
 
         Returns:
             None
@@ -1570,6 +1574,41 @@ class ADAPI:
         kwargs["__name"] = self.name
 
         self.AD.services.register_service(namespace, d, s, cb, __async="auto", **kwargs)
+
+    def deregister_service(self, service, **kwargs):
+        """Deregisters a service that had been previously registered
+
+        Using this function, an App can deregister a service call, it has initially registered in the service registry.
+        This will automatically make it unavailable to other apps using the `call_service()` API call, as well as published
+        as a service in the REST API and make it unavailable to the `call_service` command in the event stream.
+        This function can only be used, within the app that registered it in the first place
+
+        Args:
+            service: Name of the service, in the format `domain/service`.
+        Keyword Args:
+            namespace(str, optional): Namespace to use for the call. See the section on
+                `namespaces <APPGUIDE.html#namespaces>`__ for a detailed description.
+                In most cases, it is safe to ignore this parameter.
+
+        Returns:
+            Bool
+
+        Examples:
+            >>> self.deregister_service("myservices/service1")
+
+        """
+        self._check_service(service)
+        d, s = service.split("/")
+        self.logger.debug("deregister_service: %s/%s, %s", d, s, kwargs)
+
+        namespace = self._get_namespace(**kwargs)
+
+        if "namespace" in kwargs:
+            del kwargs["namespace"]
+
+        kwargs["__name"] = self.name
+
+        return self.AD.services.deregister_service(namespace, d, s, **kwargs)
 
     def list_services(self, **kwargs):
         """List all services available within AD

--- a/appdaemon/app_management.py
+++ b/appdaemon/app_management.py
@@ -29,6 +29,7 @@ class AppManagement:
         self.modules = {}
         self.objects = {}
         self.check_app_updates_profile_stats = None
+        self.check_updates_lock = None
 
         # Initialize config file tracking
 
@@ -102,6 +103,9 @@ class AppManagement:
         await self.AD.state.remove_entity("admin", "app.{}".format(name))
 
     async def init_admin_stats(self):
+        # store lock
+        self.check_updates_lock = asyncio.Lock()
+
         # create sensors
         await self.add_entity(self.active_apps_sensor, 0, {"friendly_name": "Active Apps"})
         await self.add_entity(self.inactive_apps_sensor, 0, {"friendly_name": "Inactive Apps"})
@@ -230,6 +234,8 @@ class AppManagement:
         await self.AD.callbacks.clear_callbacks(name)
 
         self.AD.futures.cancel_futures(name)
+
+        self.AD.services.clear_services(name)
 
         await self.AD.sched.terminate_app(name)
 
@@ -836,204 +842,205 @@ class AppManagement:
         fh.close()
 
     # @_timeit
-    async def check_app_updates(self, plugin=None, mode="normal"):  # noqa: C901
+    async def check_app_updates(self, plugin: str = None, mode: str = "normal"):  # noqa: C901
 
-        if self.AD.apps is False:
-            return
+        async with self.check_updates_lock:
+            if self.AD.apps is False:
+                return
 
-        # Lets add some profiling
-        pr = None
-        if self.AD.check_app_updates_profile is True:
-            pr = cProfile.Profile()
-            pr.enable()
+            # Lets add some profiling
+            pr = None
+            if self.AD.check_app_updates_profile is True:
+                pr = cProfile.Profile()
+                pr.enable()
 
-        # Process filters
+            # Process filters
 
-        await utils.run_in_executor(self, self.process_filters)
+            await utils.run_in_executor(self, self.process_filters)
 
-        # Get list of apps we need to terminate and/or initialize
+            # Get list of apps we need to terminate and/or initialize
 
-        apps = await self.check_config()
+            apps = await self.check_config()
 
-        found_files = []
-        modules = []
-        for root, subdirs, files in await utils.run_in_executor(self, os.walk, self.AD.app_dir, topdown=True):
-            # print(root, subdirs, files)
-            #
-            # Prune dir list
-            #
-            subdirs[:] = [d for d in subdirs if d not in self.AD.exclude_dirs]
+            found_files = []
+            modules = []
+            for root, subdirs, files in await utils.run_in_executor(self, os.walk, self.AD.app_dir, topdown=True):
+                # print(root, subdirs, files)
+                #
+                # Prune dir list
+                #
+                subdirs[:] = [d for d in subdirs if d not in self.AD.exclude_dirs]
 
-            if root[-11:] != "__pycache__" and root[0] != ".":
-                if root not in self.module_dirs:
-                    self.logger.info("Adding %s to module import path", root)
-                    sys.path.insert(0, root)
-                    self.module_dirs.append(root)
+                if root[-11:] != "__pycache__" and root[0] != ".":
+                    if root not in self.module_dirs:
+                        self.logger.info("Adding %s to module import path", root)
+                        sys.path.insert(0, root)
+                        self.module_dirs.append(root)
 
-            for file in files:
-                if file[-3:] == ".py" and file[0] != ".":
-                    found_files.append(os.path.join(root, file))
+                for file in files:
+                    if file[-3:] == ".py" and file[0] != ".":
+                        found_files.append(os.path.join(root, file))
 
-        for file in found_files:
-            if file == os.path.join(self.AD.app_dir, "__init__.py"):
-                continue
-            try:
-
-                # check we can actually open the file
-                await utils.run_in_executor(self, self.check_file, file)
-
-                modified = await utils.run_in_executor(self, os.path.getmtime, file)
-                if file in self.monitored_files:
-                    if self.monitored_files[file] < modified:
-                        modules.append({"name": file, "reload": True})
-                        self.monitored_files[file] = modified
-                else:
-                    self.logger.debug("Found module %s", file)
-                    modules.append({"name": file, "reload": False})
-                    self.monitored_files[file] = modified
-            except IOError as err:
-                self.logger.warning("Unable to read app %s: %s - skipping", file, err)
-
-        # Check for deleted modules and add them to the terminate list
-        deleted_modules = []
-        for file in self.monitored_files:
-            if file not in found_files or mode == "term":
-                deleted_modules.append(file)
-                self.logger.info("Removing module %s", file)
-
-        for file in deleted_modules:
-            del self.monitored_files[file]
-            for app in self.apps_per_module(self.get_module_from_path(file)):
-                apps["term"][app] = 1
-
-        # Add any apps we need to reload because of file changes
-
-        for module in modules:
-            for app in self.apps_per_module(self.get_module_from_path(module["name"])):
-                if module["reload"]:
-                    apps["term"][app] = 1
-                apps["init"][app] = 1
-
-            if "global_modules" in self.app_config:
-                for gm in utils.single_or_list(self.app_config["global_modules"]):
-                    if gm == self.get_module_from_path(module["name"]):
-                        for app in self.apps_per_global_module(gm):
-                            if module["reload"]:
-                                apps["term"][app] = 1
-                            apps["init"][app] = 1
-
-        if plugin is not None:
-            self.logger.info("Processing restart for %s", plugin)
-            # This is a restart of one of the plugins so check which apps need to be restarted
-            for app in self.app_config:
-                reload = False
-                if app in self.non_apps:
+            for file in found_files:
+                if file == os.path.join(self.AD.app_dir, "__init__.py"):
                     continue
-                if "plugin" in self.app_config[app]:
-                    for this_plugin in utils.single_or_list(self.app_config[app]["plugin"]):
-                        if this_plugin == plugin:
-                            # We got a match so do the reload
-                            reload = True
-                            break
-                        elif plugin == "__ALL__":
-                            reload = True
-                            break
-                else:
-                    # No plugin dependency specified, reload to error on the side of caution
-                    reload = True
+                try:
 
-                if reload is True:
+                    # check we can actually open the file
+                    await utils.run_in_executor(self, self.check_file, file)
+
+                    modified = await utils.run_in_executor(self, os.path.getmtime, file)
+                    if file in self.monitored_files:
+                        if self.monitored_files[file] < modified:
+                            modules.append({"name": file, "reload": True})
+                            self.monitored_files[file] = modified
+                    else:
+                        self.logger.debug("Found module %s", file)
+                        modules.append({"name": file, "reload": False})
+                        self.monitored_files[file] = modified
+                except IOError as err:
+                    self.logger.warning("Unable to read app %s: %s - skipping", file, err)
+
+            # Check for deleted modules and add them to the terminate list
+            deleted_modules = []
+            for file in self.monitored_files:
+                if file not in found_files or mode == "term":
+                    deleted_modules.append(file)
+                    self.logger.info("Removing module %s", file)
+
+            for file in deleted_modules:
+                del self.monitored_files[file]
+                for app in self.apps_per_module(self.get_module_from_path(file)):
                     apps["term"][app] = 1
+
+            # Add any apps we need to reload because of file changes
+
+            for module in modules:
+                for app in self.apps_per_module(self.get_module_from_path(module["name"])):
+                    if module["reload"]:
+                        apps["term"][app] = 1
                     apps["init"][app] = 1
 
-        # Terminate apps
+                if "global_modules" in self.app_config:
+                    for gm in utils.single_or_list(self.app_config["global_modules"]):
+                        if gm == self.get_module_from_path(module["name"]):
+                            for app in self.apps_per_global_module(gm):
+                                if module["reload"]:
+                                    apps["term"][app] = 1
+                                apps["init"][app] = 1
 
-        apps_terminated = {}  # store apps properly terminated is any
-        if apps is not None and apps["term"]:
-            prio_apps = self.get_app_deps_and_prios(apps["term"], mode)
-
-            for app in sorted(prio_apps, key=prio_apps.get, reverse=True):
-                executed = await self.stop_app(app)
-                apps_terminated[app] = executed
-
-        # Load/reload modules
-
-        for mod in modules:
-            try:
-                await utils.run_in_executor(self, self.read_app, mod["name"], mod["reload"])
-            except Exception:
-                self.error.warning("-" * 60)
-                self.error.warning("Unexpected error loading module: %s:", mod["name"])
-                self.error.warning("-" * 60)
-                self.error.warning(traceback.format_exc())
-                self.error.warning("-" * 60)
-                if self.AD.logging.separate_error_log() is True:
-                    self.logger.warning("Unexpected error loading module: %s:", mod["name"])
-
-                self.logger.warning("Removing associated apps:")
-                module = self.get_module_from_path(mod["name"])
+            if plugin is not None:
+                self.logger.info("Processing restart for %s", plugin)
+                # This is a restart of one of the plugins so check which apps need to be restarted
                 for app in self.app_config:
-                    if "module" in self.app_config[app] and self.app_config[app]["module"] == module:
-                        if apps["init"] and app in apps["init"]:
-                            del apps["init"][app]
-                            self.logger.warning("%s", app)
-                            await self.set_state(app, state="compile_error")
+                    reload = False
+                    if app in self.non_apps:
+                        continue
+                    if "plugin" in self.app_config[app]:
+                        for this_plugin in utils.single_or_list(self.app_config[app]["plugin"]):
+                            if this_plugin == plugin:
+                                # We got a match so do the reload
+                                reload = True
+                                break
+                            elif plugin == "__ALL__":
+                                reload = True
+                                break
+                    else:
+                        # No plugin dependency specified, reload to error on the side of caution
+                        reload = True
 
-        if apps is not None and apps["init"]:
+                    if reload is True:
+                        apps["term"][app] = 1
+                        apps["init"][app] = 1
 
-            prio_apps = self.get_app_deps_and_prios(apps["init"], mode)
+            # Terminate apps
 
-            # Load Apps
+            apps_terminated = {}  # store apps properly terminated is any
+            if apps is not None and apps["term"]:
+                prio_apps = self.get_app_deps_and_prios(apps["term"], mode)
 
-            for app in sorted(prio_apps, key=prio_apps.get):
+                for app in sorted(prio_apps, key=prio_apps.get, reverse=True):
+                    executed = await self.stop_app(app)
+                    apps_terminated[app] = executed
+
+            # Load/reload modules
+
+            for mod in modules:
                 try:
+                    await utils.run_in_executor(self, self.read_app, mod["name"], mod["reload"])
+                except Exception:
+                    self.error.warning("-" * 60)
+                    self.error.warning("Unexpected error loading module: %s:", mod["name"])
+                    self.error.warning("-" * 60)
+                    self.error.warning(traceback.format_exc())
+                    self.error.warning("-" * 60)
+                    if self.AD.logging.separate_error_log() is True:
+                        self.logger.warning("Unexpected error loading module: %s:", mod["name"])
+
+                    self.logger.warning("Removing associated apps:")
+                    module = self.get_module_from_path(mod["name"])
+                    for app in self.app_config:
+                        if "module" in self.app_config[app] and self.app_config[app]["module"] == module:
+                            if apps["init"] and app in apps["init"]:
+                                del apps["init"][app]
+                                self.logger.warning("%s", app)
+                                await self.set_state(app, state="compile_error")
+
+            if apps is not None and apps["init"]:
+
+                prio_apps = self.get_app_deps_and_prios(apps["init"], mode)
+
+                # Load Apps
+
+                for app in sorted(prio_apps, key=prio_apps.get):
+                    try:
+                        if "disable" in self.app_config[app] and self.app_config[app]["disable"] is True:
+                            self.logger.info("%s is disabled", app)
+                            await self.set_state(app, state="disabled")
+                            await self.increase_inactive_apps(app)
+                        else:
+                            if apps_terminated.get(app, True) is True:  # the app terminated properly
+                                await self.init_object(app)
+
+                            else:
+                                self.logger.warning("Cannot initialize app %s, as it didn't terminate properly", app)
+
+                    except Exception:
+                        error_logger = logging.getLogger("Error.{}".format(app))
+                        error_logger.warning("-" * 60)
+                        error_logger.warning("Unexpected error initializing app: %s:", app)
+                        error_logger.warning("-" * 60)
+                        error_logger.warning(traceback.format_exc())
+                        error_logger.warning("-" * 60)
+                        if self.AD.logging.separate_error_log() is True:
+                            self.logger.warning(
+                                "Logged an error to %s", self.AD.logging.get_filename("error_log"),
+                            )
+
+                await self.AD.threading.calculate_pin_threads()
+
+                # Call initialize() for apps
+
+                for app in sorted(prio_apps, key=prio_apps.get):
                     if "disable" in self.app_config[app] and self.app_config[app]["disable"] is True:
-                        self.logger.info("%s is disabled", app)
-                        await self.set_state(app, state="disabled")
-                        await self.increase_inactive_apps(app)
+                        pass
                     else:
                         if apps_terminated.get(app, True) is True:  # the app terminated properly
-                            await self.init_object(app)
+                            await self.initialize_app(app)
 
                         else:
-                            self.logger.warning("Cannot initialize app %s, as it didn't terminate properly", app)
+                            self.logger.debug("Cannot initialize app %s, as it didn't terminate properly", app)
 
-                except Exception:
-                    error_logger = logging.getLogger("Error.{}".format(app))
-                    error_logger.warning("-" * 60)
-                    error_logger.warning("Unexpected error initializing app: %s:", app)
-                    error_logger.warning("-" * 60)
-                    error_logger.warning(traceback.format_exc())
-                    error_logger.warning("-" * 60)
-                    if self.AD.logging.separate_error_log() is True:
-                        self.logger.warning(
-                            "Logged an error to %s", self.AD.logging.get_filename("error_log"),
-                        )
+            if self.AD.check_app_updates_profile is True:
+                pr.disable()
 
-            await self.AD.threading.calculate_pin_threads()
+            s = io.StringIO()
+            sortby = "cumulative"
+            ps = pstats.Stats(pr, stream=s).sort_stats(sortby)
+            ps.print_stats()
+            self.check_app_updates_profile_stats = s.getvalue()
 
-            # Call initialize() for apps
-
-            for app in sorted(prio_apps, key=prio_apps.get):
-                if "disable" in self.app_config[app] and self.app_config[app]["disable"] is True:
-                    pass
-                else:
-                    if apps_terminated.get(app, True) is True:  # the app terminated properly
-                        await self.initialize_app(app)
-
-                    else:
-                        self.logger.debug("Cannot initialize app %s, as it didn't terminate properly", app)
-
-        if self.AD.check_app_updates_profile is True:
-            pr.disable()
-
-        s = io.StringIO()
-        sortby = "cumulative"
-        ps = pstats.Stats(pr, stream=s).sort_stats(sortby)
-        ps.print_stats()
-        self.check_app_updates_profile_stats = s.getvalue()
-
-        self.apps_initialized = True
+            self.apps_initialized = True
 
     def get_app_deps_and_prios(self, applist, mode):
 

--- a/appdaemon/services.py
+++ b/appdaemon/services.py
@@ -18,7 +18,9 @@ class Services:
         self.app_registered_services = {}
         self.logger = ad.logging.get_child("_services")
 
-    def register_service(self, namespace: str, domain: str, service: str, callback: Any, **kwargs: Optional[dict]):
+    def register_service(
+        self, namespace: str, domain: str, service: str, callback: Any, **kwargs: Optional[dict]
+    ) -> None:
         self.logger.debug(
             "register_service called: %s.%s.%s -> %s", namespace, domain, service, callback,
         )
@@ -36,6 +38,16 @@ class Services:
 
             if domain not in self.services[namespace]:
                 self.services[namespace][domain] = {}
+
+            if service in self.services[namespace][domain]:
+                # there was a service already registered before
+                # so if a different app, we ask to deregister first
+                service_app = self.services[namespace][domain][service].get("__name")
+                if service_app and service_app != name:
+                    self.logger.warning(
+                        f"This service '{domain}/{service}' already registered to a different app '{service_app}'. Do deregister from app first"
+                    )
+                    return
 
             self.services[namespace][domain][service] = {"callback": callback, **kwargs}
 

--- a/appdaemon/services.py
+++ b/appdaemon/services.py
@@ -2,7 +2,7 @@ import threading
 import traceback
 import asyncio
 from copy import deepcopy
-from typing import Any, Optional
+from typing import Any, Optional, Callable
 
 from appdaemon.appdaemon import AppDaemon
 from appdaemon.exceptions import NamespaceException
@@ -19,7 +19,7 @@ class Services:
         self.logger = ad.logging.get_child("_services")
 
     def register_service(
-        self, namespace: str, domain: str, service: str, callback: Any, **kwargs: Optional[dict]
+        self, namespace: str, domain: str, service: str, callback: Callable, **kwargs: Optional[dict]
     ) -> None:
         self.logger.debug(
             "register_service called: %s.%s.%s -> %s", namespace, domain, service, callback,
@@ -138,7 +138,7 @@ class Services:
 
         return result
 
-    async def call_service(self, namespace, domain, service, data):
+    async def call_service(self, namespace: str, domain: str, service: str, data: dict) -> Any:
         self.logger.debug(
             "call_service: namespace=%s domain=%s service=%s data=%s", namespace, domain, service, data,
         )

--- a/appdaemon/services.py
+++ b/appdaemon/services.py
@@ -125,7 +125,7 @@ class Services:
             namespace, domain, service = app_service.split(":")
             self.deregister_service(namespace, domain, service, __name=name)
 
-    def list_services(self, ns: str = "global"):
+    def list_services(self, ns: str = "global") -> list:
         result = []
         with self.services_lock:
             for namespace in self.services:

--- a/docs/AD_API_REFERENCE.rst
+++ b/docs/AD_API_REFERENCE.rst
@@ -85,6 +85,7 @@ Service
 ~~~~~~~
 
 .. autofunction:: appdaemon.adapi.ADAPI.register_service
+.. autofunction:: appdaemon.adapi.ADAPI.deregister_service
 .. autofunction:: appdaemon.adapi.ADAPI.list_services
 .. autofunction:: appdaemon.adapi.ADAPI.call_service
 

--- a/docs/AD_INDEX.rst
+++ b/docs/AD_INDEX.rst
@@ -36,6 +36,7 @@ D
 * `date()   [AppDaemon API] <AD_API_REFERENCE.html#appdaemon.adapi.ADAPI.date>`__
 * `datetime()   [AppDaemon API] <AD_API_REFERENCE.html#appdaemon.adapi.ADAPI.datetime>`__
 * `days   [Constraints] <APPGUIDE.html#days>`__
+* `deregister_service()   [AppDaemon API] <AD_API_REFERENCE.html#appdaemon.adapi.ADAPI.deregister_service>`__
 * `device_tracker   [Widget] <DASHBOARD_CREATION.html#device-tracker>`__
 
 E

--- a/docs/APPGUIDE.rst
+++ b/docs/APPGUIDE.rst
@@ -1517,6 +1517,7 @@ Assistant bus:
 -  ``plugin_started`` - fired when a plugin is initialized and properly setup e.g. connection to Home Assistant. It is fired within the plugin's namespace
 -  ``plugin_stopped`` - fired when a plugin terminates, or becomes internally unstable like a disconnection from an external system like an MQTT broker. It is fired within the plugin's namespace
 -  ``service_registered`` - fired when a service is registered in AD. It is fired within the namespace it was registered
+-  ``service_deregistered`` - fired when a service is deregistered in AD. It is fired within the namespace it was deregistered
 - ``stream_connected`` - fired when a stream client connects like the Admin User Interface. It is fired within the `admin` namespace
 - ``stream_disconnected`` - fired when a stream client disconnects like the Admin User Interface. It is fired within the `admin` namespace
 

--- a/docs/HISTORY.rst
+++ b/docs/HISTORY.rst
@@ -7,6 +7,7 @@ Change Log
 **Features**
 
 - Added "get_logs" command to stream
+- Added "deregister_service" api call
 - Added the use of the ``!include`` directive in AD. This can be used either in the main ``appdaemon`` or ``apps`` config
 - Added support for Python 3.9
 - Added the ability to auto set return for the navigate widget - contributed by `Christian Lyra <https://github.com/clyra>`__
@@ -22,6 +23,7 @@ Change Log
 - Fixed issue with when a plugin that is persistent re-initializes, and it creates an error
 - Fixed issue with when an entity has no state, and if wanting to listen to it, breaks internally
 - Fixed a couple of scheduler issues that affected tmezones west of EDT
+- Ensured that when apps with registered services are terminated, their services are also deregistered
 - Documentation fixes - contributed by `sithmein <https://github.com/sithmein>`__
 
 **Breaking Changes**

--- a/docs/HISTORY.rst
+++ b/docs/HISTORY.rst
@@ -8,6 +8,7 @@ Change Log
 
 - Added "get_logs" command to stream
 - Added "deregister_service" api call
+- Added new AD event `service_deregistered`. This is fired when an app's service is deregistered
 - Added the use of the ``!include`` directive in AD. This can be used either in the main ``appdaemon`` or ``apps`` config
 - Added support for Python 3.9
 - Added the ability to auto set return for the navigate widget - contributed by `Christian Lyra <https://github.com/clyra>`__


### PR DESCRIPTION
This PR implements a `deregister_service` api, and at the same time clears services which have been registered to a certain app. This ensures the services are not available when the app tied to it is closed.

Fulfils #1191  