### PR TITLE
Changed unregister to deregister api calls

### DIFF
--- a/appdaemon/adapi.py
+++ b/appdaemon/adapi.py
@@ -1159,7 +1159,7 @@ class ADAPI:
             return None
 
     @utils.sync_wrapper
-    async def unregister_endpoint(self, handle):
+    async def deregister_endpoint(self, handle):
         """Removes a previously registered endpoint.
 
         Args:
@@ -1169,10 +1169,10 @@ class ADAPI:
             None.
 
         Examples:
-            >>> self.unregister_endpoint(handle)
+            >>> self.deregister_endpoint(handle)
 
         """
-        await self.AD.http.unregister_endpoint(handle, self.name)
+        await self.AD.http.deregister_endpoint(handle, self.name)
 
     #
     # Web Route
@@ -1218,7 +1218,7 @@ class ADAPI:
             return None
 
     @utils.sync_wrapper
-    async def unregister_route(self, handle):
+    async def deregister_route(self, handle):
         """Removes a previously registered app route.
 
         Args:
@@ -1228,10 +1228,10 @@ class ADAPI:
             None.
 
         Examples:
-            >>> self.unregister_route(handle)
+            >>> self.deregister_route(handle)
 
         """
-        await self.AD.http.unregister_route(handle, self.name)
+        await self.AD.http.deregister_route(handle, self.name)
 
     #
     # State

--- a/appdaemon/adapi.py
+++ b/appdaemon/adapi.py
@@ -1159,7 +1159,7 @@ class ADAPI:
             return None
 
     @utils.sync_wrapper
-    async def deregister_endpoint(self, handle):
+    async def deregister_endpoint(self, handle: str) -> None:
         """Removes a previously registered endpoint.
 
         Args:
@@ -1218,7 +1218,7 @@ class ADAPI:
             return None
 
     @utils.sync_wrapper
-    async def deregister_route(self, handle):
+    async def deregister_route(self, handle: str) -> None:
         """Removes a previously registered app route.
 
         Args:

--- a/appdaemon/http.py
+++ b/appdaemon/http.py
@@ -897,7 +897,7 @@ class HTTP:
 
         return handle
 
-    async def unregister_endpoint(self, handle, name):
+    async def deregister_endpoint(self, handle, name):
         if name in self.endpoints and handle in self.endpoints[name]:
             del self.endpoints[name][handle]
 
@@ -938,7 +938,7 @@ class HTTP:
 
         return handle
 
-    async def unregister_route(self, handle, name):
+    async def deregister_route(self, handle, name):
         if name in self.app_routes and handle in self.app_routes[name]:
             del self.app_routes[name][handle]
 

--- a/docs/AD_API_REFERENCE.rst
+++ b/docs/AD_API_REFERENCE.rst
@@ -294,13 +294,13 @@ API
 ~~~
 
 .. autofunction:: appdaemon.adapi.ADAPI.register_endpoint
-.. autofunction:: appdaemon.adapi.ADAPI.unregister_endpoint
+.. autofunction:: appdaemon.adapi.ADAPI.deregister_endpoint
 
 WebRoute
 ~~~
 
 .. autofunction:: appdaemon.adapi.ADAPI.register_route
-.. autofunction:: appdaemon.adapi.ADAPI.unregister_route
+.. autofunction:: appdaemon.adapi.ADAPI.deregister_route
 
 Other
 ~~~~~

--- a/docs/AD_INDEX.rst
+++ b/docs/AD_INDEX.rst
@@ -37,6 +37,8 @@ D
 * `datetime()   [AppDaemon API] <AD_API_REFERENCE.html#appdaemon.adapi.ADAPI.datetime>`__
 * `days   [Constraints] <APPGUIDE.html#days>`__
 * `device_tracker   [Widget] <DASHBOARD_CREATION.html#device-tracker>`__
+* `deregister_endpoint()   [AppDaemon API] <AD_API_REFERENCE.html#appdaemon.adapi.ADAPI.deregister_endpoint>`__
+* `deregister_route()   [AppDaemon API] <AD_API_REFERENCE.html#appdaemon.adapi.ADAPI.deregister_route>`__
 
 E
 -
@@ -224,9 +226,6 @@ T
 
 U
 -
-
-* `unregister_endpoint()   [AppDaemon API] <AD_API_REFERENCE.html#appdaemon.adapi.ADAPI.unregister_endpoint>`__
-* `unregister_route()   [AppDaemon API] <AD_API_REFERENCE.html#appdaemon.adapi.ADAPI.unregister_route>`__
 
 V
 -

--- a/docs/APPGUIDE.rst
+++ b/docs/APPGUIDE.rst
@@ -1972,7 +1972,7 @@ as specified in the configuration file.
 Apps can have as many endpoints as required, however, the names must be unique across
 all of the Apps in an AppDaemon instance.
 
-It is also possible to remove endpoints with the ``unregister_endpoint()`` call, making the
+It is also possible to remove endpoints with the ``deregister_endpoint()`` call, making the
 endpoints truly dynamic and under the control of the App.
 
 Here is an example of an App using the API:

--- a/docs/HISTORY.rst
+++ b/docs/HISTORY.rst
@@ -27,6 +27,8 @@ Change Log
 **Breaking Changes**
 
 - Dropped support for Python 3.6
+- Changed `unregister_endpoint` to `deregister_endpoint`
+- Changed `unregister_route` to `deregister_route`
 
 4.0.8 (2021-03-30)
 ------------------


### PR DESCRIPTION
This PR changes the `unregister_...` api calls to `deregister`. This allows to standardize the api calls for those using the `register_...` as a way to call it. Though unfortunately a breaking change