### PR TITLE
App endpoint

### DIFF
--- a/appdaemon/adapi.py
+++ b/appdaemon/adapi.py
@@ -1149,8 +1149,14 @@ class ADAPI:
             and an HTTP OK status response (e.g., `200`. If this is not added as a returned response,
             the function will generate an error each time it is processed.
 
-            >>> self.register_endpoint(my_callback)
-            >>> self.register_endpoint(alexa_cb, "alexa")
+            >>> self.register_endpoint(self.my_callback)
+            >>> self.register_endpoint(self.alexa_cb, "alexa")
+
+            >>> async def alexa_cb(self, request, kwargs):
+            >>>     data = await request.json()
+            >>>     self.log(data)
+            >>>     response = {"message": "Hello World"}
+            >>>     return response, 200
 
         """
         if endpoint is None:

--- a/appdaemon/adapi.py
+++ b/appdaemon/adapi.py
@@ -5,6 +5,7 @@ import iso8601
 import re
 from datetime import timedelta
 from copy import deepcopy
+from typing import Callable, Optional, Any
 
 # needed for fake coro cb that looks like scheduler
 import uuid
@@ -1127,12 +1128,18 @@ class ADAPI:
     #
 
     @utils.sync_wrapper
-    async def register_endpoint(self, callback, name=None):
+    async def register_endpoint(
+        self, callback: Callable[[Any, dict], Any], endpoint: str = None, **kwargs: Optional[dict]
+    ) -> str:
         """Registers an endpoint for API calls into the current App.
 
         Args:
             callback: The function to be called when a request is made to the named endpoint.
-            name (str, optional): The name of the endpoint to be used for the call  (Default: ``None``).
+            endpoint (str, optional): The name of the endpoint to be used for the call  (Default: ``None``).
+            This must be unique across all endpoints, and when not given, the name of the app is used as the endpoint.
+            It is possible to register multiple endpoints to a single app instance.
+        Keyword Args:
+            **kwargs (optional): Zero or more keyword arguments.
 
         Returns:
             A handle that can be used to remove the registration.
@@ -1143,20 +1150,18 @@ class ADAPI:
             the function will generate an error each time it is processed.
 
             >>> self.register_endpoint(my_callback)
-            >>> self.register_callback(alexa_cb, "alexa")
+            >>> self.register_endpoint(alexa_cb, "alexa")
 
         """
-        if name is None:
-            ep = self.name
-        else:
-            ep = name
+        if endpoint is None:
+            endpoint = self.name
+
         if self.AD.http is not None:
-            return await self.AD.http.register_endpoint(callback, ep)
+            return await self.AD.http.register_endpoint(callback, endpoint, self.name, **kwargs)
         else:
             self.logger.warning(
-                "register_endpoint for %s filed - HTTP component is not configured", name,
+                "register_endpoint for %s failed - HTTP component is not configured", endpoint,
             )
-            return None
 
     @utils.sync_wrapper
     async def deregister_endpoint(self, handle: str) -> None:
@@ -1179,7 +1184,9 @@ class ADAPI:
     #
 
     @utils.sync_wrapper
-    async def register_route(self, callback, route=None, **kwargs):
+    async def register_route(
+        self, callback: Callable[[Any, dict], Any], route: str = None, **kwargs: Optional[dict]
+    ) -> str:
         """Registers a route for Web requests into the current App.
            By registering an app web route, this allows to make use of AD's internal web server to serve
            web clients. All routes registered using this api call, can be accessed using
@@ -1190,10 +1197,7 @@ class ADAPI:
             route (str, optional): The name of the route to be used for the request (Default: the app's name).
 
         Keyword Args:
-            token (str, optional): A previously registered token can be passed with the api call, which
-            can be used to secure the app route. This allows for different security credentials to be used across different
-            app routes. It should be noted that if a device has already registered using AD's Admin UI's password
-            and a cookie has been stored by the browser, that device will bypass the token and still access the web server.
+            **kwargs (optional): Zero or more keyword arguments.
 
         Returns:
             A handle that can be used to remove the registration.
@@ -1215,7 +1219,6 @@ class ADAPI:
 
         else:
             self.logger.warning("register_route for %s filed - HTTP component is not configured", route)
-            return None
 
     @utils.sync_wrapper
     async def deregister_route(self, handle: str) -> None:

--- a/appdaemon/http.py
+++ b/appdaemon/http.py
@@ -929,7 +929,12 @@ class HTTP:
             if asyncio.iscoroutinefunction(callback):
                 return await callback(request, rargs)
             else:
-                return await utils.run_in_executor(self, callback, request, rargs)
+                try:
+                    args = await request.json()
+                except json.decoder.JSONDecodeError:
+                    return self.get_response(request, 400, "JSON Decode Error")
+
+                return await utils.run_in_executor(self, callback, args, rargs)
         else:
             return "", 404
 

--- a/docs/APPGUIDE.rst
+++ b/docs/APPGUIDE.rst
@@ -1946,12 +1946,11 @@ RESTFul API Support
 -------------------
 
 AppDaemon supports a simple RESTFul API to enable arbitrary HTTP
-connections to pass data to Apps and trigger actions. API Calls must use
-a content type of ``application/json``, and the response will be JSON
+connections to pass data to Apps and trigger actions via a `POST` request.
+API Calls can be anything, and the response will be JSON
 encoded. The RESTFul API is disabled by default, but is enabled by
-adding an ``api_port`` directive to the AppDaemon section of the
-configuration file. The API can run http or https if desired, separately
-from the dashboard.
+setting up the `http` component in the configuration file.
+The API can run http or https if desired, separately from the dashboard.
 
 To call into a specific App, construct a URL, use the regular
 HADashboard URL, and append ``/api/appdaemon``, then add the name of the
@@ -1986,7 +1985,9 @@ Here is an example of an App using the API:
         def initialize(self):
             self.register_endpoint(my_callback, "test_endpoint")
 
-        def my_callback(self, data):
+        async def my_callback(self, request, kwargs):
+
+            data = await request.json()
 
             self.log(data)
 
@@ -2002,9 +2003,9 @@ caller, ``200`` should be used for an OK response.
 As well as any user specified code, the API can return the following
 codes:
 
--  400 - JSON Decode Error
 -  401 - Unauthorized
 -  404 - App not found
+-  500 - Internal Server Error
 
 Below is an example of using curl to call into the App shown above:
 

--- a/docs/APPGUIDE.rst
+++ b/docs/APPGUIDE.rst
@@ -1995,6 +1995,11 @@ Here is an example of an App using the API:
 
             return response, 200
 
+If the supplied callback is not `async` as in the example above, AD will pass only the
+JSON data from the request to the callback; essentially running `data = await request.json()`.
+Since the request object needs to be parsed within an `async` callback.
+Thereby making only available a dictionary, instead of the request object.
+
 The response must be a python structure that can be mapped to JSON, or
 can be blank, in which case specify ``""`` for the response. You should
 also return an HTML status code, that will be reported back to the
@@ -2003,6 +2008,7 @@ caller, ``200`` should be used for an OK response.
 As well as any user specified code, the API can return the following
 codes:
 
+-  400 - JSON Decode Error
 -  401 - Unauthorized
 -  404 - App not found
 -  500 - Internal Server Error

--- a/docs/HISTORY.rst
+++ b/docs/HISTORY.rst
@@ -16,12 +16,15 @@ Change Log
 - Bumped wheel from 0.34.2 to 0.36.2
 - Bumped azure-storage-blob from 12.8.0 to 12.8.1
 - Bumped azure-mgmt-resource from 16.0.0 to 16.1.0
+- When apps register endpoints, `kwargs` can be added which is made available at the callback
+- The request object is now made available in the app endpoint callback, allowing for better flexibility
 
 **Fixes**
 
 - Fixed issue with when a plugin that is persistent re-initializes, and it creates an error
 - Fixed issue with when an entity has no state, and if wanting to listen to it, breaks internally
 - Fixed a couple of scheduler issues that affected tmezones west of EDT
+- Fixed issue of app endpoints not being cleared when app is terminated
 - Documentation fixes - contributed by `sithmein <https://github.com/sithmein>`__
 
 **Breaking Changes**
@@ -29,6 +32,9 @@ Change Log
 - Dropped support for Python 3.6
 - Changed `unregister_endpoint` to `deregister_endpoint`
 - Changed `unregister_route` to `deregister_route`
+- Changed the callback signature for `register_endpoint`. Please see example `here <https://appdaemon.readthedocs.io/en/latest/APPGUIDE.html#restful-api-support>`__
+- Changed the callback signature for `register_route`
+- Changed the arg `name` for `register_endpoint` to `endpoint`
 
 4.0.8 (2021-03-30)
 ------------------

--- a/docs/HISTORY.rst
+++ b/docs/HISTORY.rst
@@ -17,14 +17,16 @@ Change Log
 - Bumped azure-storage-blob from 12.8.0 to 12.8.1
 - Bumped azure-mgmt-resource from 16.0.0 to 16.1.0
 - When apps register endpoints, `kwargs` can be added which is made available at the callback
-- The request object is now made available in the app endpoint callback, allowing for better flexibility
+- The request object is now made available in the app endpoint callback if using `async`, allowing for better flexibility
 
 **Fixes**
 
 - Fixed issue with when a plugin that is persistent re-initializes, and it creates an error
 - Fixed issue with when an entity has no state, and if wanting to listen to it, breaks internally
 - Fixed a couple of scheduler issues that affected tmezones west of EDT
-- Fixed issue of app endpoints not being cleared when app is terminated
+- Fixed issue of app endpoints not being cleaned when app is terminated
+- Fixed issue where it was possible for different apps to register against the same endpoint
+- Fixed issue whereby the wrong response code was sent, when there was a server error
 - Documentation fixes - contributed by `sithmein <https://github.com/sithmein>`__
 
 **Breaking Changes**


### PR DESCRIPTION
This PR fixes the following
- An issue where by app registered endpoints where not cleared when the app was terminated
- The wrong server code being sent, even when there was an error in the callback
- Multiple apps being allowed to register to the same endpoint


It added the following features:
- Allows for passing of the request object, back to the callback when using async
- When still using a sync callback, it will only pass the JSON payload as it does presently
- App can now properly manage multiple endpoints

Unfortunately there is a breaking change, due to the change in the signature of the callback, which keeps it in line with other AD callbacks. Also this PR adds an existing PR #1296, since it has the same target.