### PR TITLE
Climate: Fix unit display from config

### DIFF
--- a/appdaemon/widgets/climate.yaml
+++ b/appdaemon/widgets/climate.yaml
@@ -6,7 +6,7 @@ post_service:
 fields:
   title: "{{title}}"
   title2: "{{title2}}"
-  units: "{{units}}"
+  units: ""
   level: ""
   level2: ""
 icons: []


### PR DESCRIPTION
This fixes the unit displaying issue to allow for the units to be set in the YAML correctly.