### PR TITLE
Fixing hadashboard on old IOS devices

### DIFF
--- a/appdaemon/widgets/basejavascript/basejavascript.js
+++ b/appdaemon/widgets/basejavascript/basejavascript.js
@@ -138,8 +138,9 @@ function basejavascript(widget_id, url, skin, parameters)
         {
             if ("timeout" in parameters)
             {
-                try {
-                    current_dash = location.pathname.split('/')[1];
+                current_dash = location.pathname.split('/')[1];
+		if (current_dash.lenght > 0) 
+		{
                     if (i == 0)
                     {
                         url = url + "?return=" + current_dash;
@@ -149,13 +150,9 @@ function basejavascript(widget_id, url, skin, parameters)
                     {
                         url = url + "&return=" + current_dash;
                         i++
-                    }
+                     }
                 }
-                catch
-                {
-                    console.log('failled to auto-set return dashboard')
-                }
-            }
+            } 
         }
         if ("timeout" in parameters)
         {


### PR DESCRIPTION
It seems that the old IOS devices doesnt support try/catch statements and there's one on basejavascript. This PR removes that try/catch and now the dev branch is working on my ipad2/ios 9.3.5.