### PR TITLE
Document old and new callback parameters are strings

### DIFF
--- a/appdaemon/adapi.py
+++ b/appdaemon/adapi.py
@@ -1272,10 +1272,10 @@ class ADAPI:
                 state change within the specified entity, and supply the callback functions with
                 the entire state dictionary for the specified entity rather than an individual
                 attribute value.
-            new (str, optional): If ``new`` is supplied as a parameter, callbacks will only be made if the
+            new (optional): If ``new`` is supplied as a parameter, callbacks will only be made if the
                 state of the selected attribute (usually state) in the new state match the value
                 of ``new``.
-            old (str, optional): If ``old`` is supplied as a parameter, callbacks will only be made if the
+            old (optional): If ``old`` is supplied as a parameter, callbacks will only be made if the
                 state of the selected attribute (usually state) in the old state match the value
                 of ``old``.
 

--- a/appdaemon/adapi.py
+++ b/appdaemon/adapi.py
@@ -1274,10 +1274,8 @@ class ADAPI:
                 attribute value.
             new (optional): If ``new`` is supplied as a parameter, callbacks will only be made if the
                 state of the selected attribute (usually state) in the new state match the value
-                of ``new``. Be careful when assuming specific data types in this argument. The primary
-                attribute of a Home Assistant entity will always be a string, while MQTT and other APIs
-                may be more strongly typed. If ``attribute`` is provided, Home Assistant may provide more
-                strongly typed values depending on the individual integration.
+                of ``new``. The parameter type is defined by the namespace or plugin that is responsible
+                for the entity. If it looks like a float, list, or dictionary, it may actually be a string.
             old (optional): If ``old`` is supplied as a parameter, callbacks will only be made if the
                 state of the selected attribute (usually state) in the old state match the value
                 of ``old``. The same caveats on types for the ``new`` parameter apply to this parameter.

--- a/appdaemon/adapi.py
+++ b/appdaemon/adapi.py
@@ -1272,10 +1272,10 @@ class ADAPI:
                 state change within the specified entity, and supply the callback functions with
                 the entire state dictionary for the specified entity rather than an individual
                 attribute value.
-            new (optional): If ``new`` is supplied as a parameter, callbacks will only be made if the
+            new (str, optional): If ``new`` is supplied as a parameter, callbacks will only be made if the
                 state of the selected attribute (usually state) in the new state match the value
                 of ``new``.
-            old (optional): If ``old`` is supplied as a parameter, callbacks will only be made if the
+            old (str, optional): If ``old`` is supplied as a parameter, callbacks will only be made if the
                 state of the selected attribute (usually state) in the old state match the value
                 of ``old``.
 

--- a/appdaemon/adapi.py
+++ b/appdaemon/adapi.py
@@ -1280,7 +1280,7 @@ class ADAPI:
                 strongly typed values depending on the individual integration.
             old (optional): If ``old`` is supplied as a parameter, callbacks will only be made if the
                 state of the selected attribute (usually state) in the old state match the value
-                of ``old``. The same caveats on types for the ``new`` parameter apply to the old parameter.
+                of ``old``. The same caveats on types for the ``new`` parameter apply to this parameter.
 
             duration (int, optional): If ``duration`` is supplied as a parameter, the callback will not
                 fire unless the state listened for is maintained for that number of seconds. This

--- a/appdaemon/adapi.py
+++ b/appdaemon/adapi.py
@@ -1274,10 +1274,13 @@ class ADAPI:
                 attribute value.
             new (optional): If ``new`` is supplied as a parameter, callbacks will only be made if the
                 state of the selected attribute (usually state) in the new state match the value
-                of ``new``.
+                of ``new``. Be careful when assuming specific data types in this argument. The primary
+                attribute of a Home Assistant entity will always be a string, while MQTT and other APIs
+                may be more strongly typed. If ``attribute`` is provided, Home Assistant may provide more
+                strongly typed values depending on the individual integration.
             old (optional): If ``old`` is supplied as a parameter, callbacks will only be made if the
                 state of the selected attribute (usually state) in the old state match the value
-                of ``old``.
+                of ``old``. The same caveats on types for the ``new`` parameter apply to the old parameter.
 
             duration (int, optional): If ``duration`` is supplied as a parameter, the callback will not
                 fire unless the state listened for is maintained for that number of seconds. This


### PR DESCRIPTION
Following up from https://github.com/AppDaemon/appdaemon/issues/1366, this makes it explicit that the old and new parameters are always strings, as that's how HomeAssistant stores them.