### PR TITLE
Hass startup fix

### DIFF
--- a/appdaemon/plugins/hass/hassplugin.py
+++ b/appdaemon/plugins/hass/hassplugin.py
@@ -749,24 +749,23 @@ class HassPlugin(PluginBase):
 
             # manually added HASS services
             new_services = {}
-            new_services["database"] = [{"history": {}}]
-            new_services["template"] = [{"render": {}}]
+            new_services["database"] = {"history": {}}
+            new_services["template"] = {"render": {}}
 
             # now add the services
             for i, service in enumerate(deepcopy(services)):
                 domain = service["domain"]
                 if domain in new_services:
                     # the domain already exists
-                    for new_service in new_services[domain]:
-                        services[i]["services"] = new_service
+                    services[i]["services"].update(new_services[domain])
 
                     # remove from the list
                     del new_services[domain]
 
             if len(new_services) > 0:  # some have not been processed
                 for domain, service in new_services.items():
-                    for serv in service:
-                        services.append({"domain": domain, "services": serv})
+                    services.append({"domain": domain, "services": {}})
+                    services[-1]["services"].update(service)
 
             return services
 

--- a/docs/HISTORY.rst
+++ b/docs/HISTORY.rst
@@ -12,6 +12,7 @@ None
 
 - Pinned socketio modules to fix a version mismatch
 - Removed try/catch clause that broke dashboard for iOS 10 users - contributed by `Christian Lyra <https://github.com/clyra>`__
+- Fix for Hass services not being captured after startup again
 
 **Breaking Changes**
 


### PR DESCRIPTION
In the hopefully final fix, when the plugin starts up, it will still query HA for services every minutes over the first 10 minutes.

This way any other services not yet captures, will then be registered within AD.

In the process, fixed other services related issues, which was somehow masked all these while. Maybe because user's have not attempted to make use of services in a certain combination. 