### PR TITLE
Sequences wait state

### DIFF
--- a/appdaemon/adapi.py
+++ b/appdaemon/adapi.py
@@ -586,7 +586,7 @@ class ADAPI:
     @utils.sync_wrapper
     async def _check_entity(self, namespace, entity):
         if "." not in entity:
-            raise ValueError("{}: Invalid entity ID: {}".format(self.name, entity))
+            raise ValueError(f"{self.name}: Invalid entity ID: {entity}")
         if not await self.AD.state.entity_exists(namespace, entity):
             self.logger.warning("%s: Entity %s not found in namespace %s", self.name, entity, namespace)
 
@@ -3094,6 +3094,11 @@ class ADAPI:
         entity_id = Entity(self.logger, self.AD, self.name, namespace, entity)
 
         return entity_id
+
+    def get_entity_api(self, namespace: str, entity_id: str) -> Entity:
+        api = Entity.entity_api(self.logger, self.AD, self.name, namespace, entity_id)
+
+        return api
 
     def run_in_thread(self, callback, thread, **kwargs):
         """Schedules a callback to be run in a different thread from the current one.

--- a/appdaemon/adapi.py
+++ b/appdaemon/adapi.py
@@ -1743,12 +1743,12 @@ class ADAPI:
         return await self.AD.services.call_service(namespace, d, s, kwargs)
 
     @utils.sync_wrapper
-    async def run_sequence(self, sequence, **kwargs):
+    async def run_sequence(self, sequence: Union[str, list], **kwargs: Optional[dict]):
         """Run an AppDaemon Sequence. Sequences are defined in a valid apps.yaml file or inline, and are sequences of
         service calls.
 
         Args:
-            sequence: The sequence name, referring to the correct entry in apps.yaml, or a dict containing
+            sequence: The sequence name, referring to the correct entry in apps.yaml, or a list containing
                 actual commands to run
             **kwargs (optional): Zero or more keyword arguments.
 
@@ -1779,27 +1779,27 @@ class ADAPI:
             del kwargs["namespace"]
 
         _name = self.name
-        self.logger.debug("Calling run_sequence() for %s", self.name)
+        self.logger.debug("Calling run_sequence() for %s from %s", sequence, self.name)
         return await self.AD.sequences.run_sequence(_name, namespace, sequence, **kwargs)
 
     @utils.sync_wrapper
-    async def cancel_sequence(self, handle):
-        """Cancel an AppDaemon Sequence.
+    async def cancel_sequence(self, sequence: Any) -> None:
+        """Cancel an already running AppDaemon Sequence.
 
         Args:
-            handle: The handle returned by the `run_sequence()` call
+            sequence: The sequence as configured to be cancelled, or the sequence entity_id or future object
 
         Returns:
             None.
 
         Examples:
 
-            >>> self.run_sequence(handle)
+            >>> self.cancel_sequence("sequence.living_room_lights")
 
         """
-        _name = self.name
-        self.logger.debug("Calling run_sequence() for %s", self.name)
-        await self.AD.sequences.cancel_sequence(_name, handle)
+
+        self.logger.debug("Calling cancel_sequence() for %s, from %s", sequence, self.name)
+        await self.AD.sequences.cancel_sequence(sequence)
 
     #
     # Events

--- a/appdaemon/adbase.py
+++ b/appdaemon/adbase.py
@@ -4,7 +4,6 @@ from copy import deepcopy
 
 import appdaemon.utils as utils
 import appdaemon.adapi as adapi
-from appdaemon.entity import Entity
 from appdaemon.appdaemon import AppDaemon
 
 
@@ -99,11 +98,6 @@ class ADBase:
 
     def get_ad_api(self):
         api = adapi.ADAPI(self.AD, self.name, self._logging, self.args, self.config, self.app_config, self.global_vars,)
-
-        return api
-
-    def get_entity_api(self, namespace: str, entity_id: str) -> Entity:
-        api = Entity.entity_api(self.logger, self.AD, self.name, namespace, entity_id)
 
         return api
 

--- a/appdaemon/app_management.py
+++ b/appdaemon/app_management.py
@@ -363,6 +363,29 @@ class AppManagement:
             "running": False,
         }
 
+    def init_sequence_object(self, name, object):
+        """Initialize the sequence"""
+
+        self.objects[name] = {
+            "type": "sequence",
+            "object": object,
+            "id": uuid.uuid4().hex,
+            "pin_app": False,
+            "pin_thread": -1,
+            "running": False,
+        }
+
+    async def terminate_sequence(self, name: str) -> bool:
+        """Terminate the sequence"""
+
+        if name in self.objects:
+            del self.objects[name]
+
+        await self.AD.callbacks.clear_callbacks(name)
+        self.AD.futures.cancel_futures(name)
+
+        return True
+
     async def read_config(self):  # noqa: C901
 
         new_config = None

--- a/appdaemon/sequences.py
+++ b/appdaemon/sequences.py
@@ -201,8 +201,8 @@ class Sequences:
                         else:
                             domain, service = str.split(command, "/")
                             parameters["__name"] = entity_id
-                            params = copy.deepcopy(parameters)
                             loop_step = parameters.pop("loop_step", None)
+                            params = copy.deepcopy(parameters)
                             await self.AD.services.call_service(ns, domain, service, params)
 
                             if isinstance(loop_step, dict):  # we need to loop this command multiple times

--- a/appdaemon/sequences.py
+++ b/appdaemon/sequences.py
@@ -21,7 +21,7 @@ class Sequences:
 
         # await self.run_sequence("_services", namespace, kwargs["entity_id"])
         if service == "run":
-            self.AD.thread_async.call_async_no_wait(self.run_sequence, "_services", namespace, entity_id)
+            asyncio.create_task(self.run_sequence("_services", namespace, entity_id))
 
         elif service == "cancel" and isinstance(entity_id, str):
             _, entity_name = entity_id.split(".")

--- a/appdaemon/sequences.py
+++ b/appdaemon/sequences.py
@@ -2,6 +2,8 @@ import uuid
 import asyncio
 
 from appdaemon.appdaemon import AppDaemon
+from appdaemon.entity import Entity
+from appdaemon.exceptions import TimeOutException
 
 
 class Sequences:
@@ -15,8 +17,17 @@ class Sequences:
             self.logger.warning("entity_id not given in service call, so will not be executing %s", service)
             return
 
+        entity_id = kwargs["entity_id"]
+
         # await self.run_sequence("_services", namespace, kwargs["entity_id"])
-        self.AD.thread_async.call_async_no_wait(self.run_sequence, "_services", namespace, kwargs["entity_id"])
+        if service == "run":
+            self.AD.thread_async.call_async_no_wait(self.run_sequence, "_services", namespace, entity_id)
+
+        elif service == "cancel" and isinstance(entity_id, str):
+            _, entity_name = entity_id.split(".")
+            name = f"sequence_{entity_name}"
+            self.AD.futures.cancel_futures(name)
+            await self.AD.state.set_state("_sequences", "rules", entity_id, state="idle")
 
     async def add_sequences(self, sequences):
         for sequence in sequences:
@@ -26,6 +37,11 @@ class Sequences:
                 "loop": sequences[sequence].get("loop", False),
                 "steps": sequences[sequence]["steps"],
             }
+
+            sequence_namespace = sequences[sequence].get("namespace")
+
+            if sequence_namespace is not None:
+                attributes.update({"namespace": sequence_namespace})
 
             if not await self.AD.state.entity_exists("rules", entity):
                 # it doesn't exist so add it
@@ -37,11 +53,18 @@ class Sequences:
                     "_sequences", "rules", entity, state="idle", attributes=attributes, replace=True
                 )
 
+            # create sequence objects
+            sequence_name = f"sequence_{sequence}"
+            self.AD.app_management.init_sequence_object(sequence_name, self)
+
     async def remove_sequences(self, sequences):
         if not isinstance(sequences, list):
             sequences = [sequences]
 
         for sequence in sequences:
+            # remove sequence
+            sequence_name = f"sequence_{sequence}"
+            await self.AD.app_management.terminate_sequence(sequence_name)
             await self.AD.state.remove_entity("rules", "sequence.{}".format(sequence))
 
     async def run_sequence(self, _name, namespace, sequence):
@@ -51,14 +74,22 @@ class Sequences:
         # OK, lets run it
         #
 
-        future = asyncio.ensure_future(coro)
-        self.AD.futures.add_future(_name, future)
+        if isinstance(sequence, str):
+            _, entity_name = sequence.split(".")
+            name = f"sequence_{entity_name}"
+
+        else:
+            name = _name
+
+        future = asyncio.create_task(coro)
+        self.AD.futures.add_future(name, future)
 
         return future
 
     async def prep_sequence(self, _name, namespace, sequence):
         ephemeral_entity = False
         loop = False
+
         if isinstance(sequence, str):
             entity_id = sequence
             if await self.AD.state.entity_exists("rules", entity_id) is False:
@@ -68,6 +99,8 @@ class Sequences:
             entity = await self.AD.state.get_state("_services", "rules", sequence, attribute="all")
             seq = entity["attributes"]["steps"]
             loop = entity["attributes"]["loop"]
+            ns = entity["attributes"].get("namespace", namespace)
+
         else:
             #
             # Assume it's a list with the actual commands in it
@@ -79,9 +112,9 @@ class Sequences:
             await self.AD.state.add_entity("rules", entity_id, "idle", attributes={"steps": sequence})
 
             seq = sequence
+            ns = namespace
 
-        coro = await self.do_steps(namespace, entity_id, seq, ephemeral_entity, loop)
-
+        coro = await self.do_steps(ns, entity_id, seq, ephemeral_entity, loop)
         return coro
 
     @staticmethod
@@ -96,19 +129,52 @@ class Sequences:
             while True:
                 for step in seq:
                     for command, parameters in step.items():
+                        if isinstance(parameters, dict) and "namespace" in parameters:
+                            ns = parameters["namespace"]
+                            del parameters["namespace"]
+                        else:
+                            ns = namespace
+
                         if command == "sleep":
                             await asyncio.sleep(float(parameters))
+
                         elif command == "sequence":
                             # Running a sub-sequence so just recurse
                             await self.prep_sequence("_sequence", namespace, parameters)
-                            pass
+
+                        elif command == "wait_state":
+                            if ephemeral_entity is True:
+                                self.logger.warning("Cannot process command 'wait_state', as not supported in sequence")
+                                continue
+
+                            _, entity_name = entity_id.split(".")
+                            name = f"sequence_{entity_name}"
+
+                            wait_entity = parameters.get("entity_id")
+
+                            if wait_entity is None:
+                                self.logger.warning("Cannot process command 'wait_state', as entity_id not given")
+                                continue
+
+                            state = parameters.get("state")
+                            attribute = parameters.get("attribute")
+                            duration = parameters.get("duration", 0)
+                            timeout = parameters.get("timeout")
+
+                            # now we create the wait entity object
+                            entity_object = Entity(self.logger, self.AD, name, ns, wait_entity)
+                            if not entity_object.exists():
+                                self.logger.warning(f"Waiting for an entity {wait_entity}, that doesn't exist")
+
+                            try:
+                                await entity_object.wait_state(state, attribute, duration, timeout)
+                            except TimeOutException:
+                                self.logger.warning(
+                                    f"{entity_name} sequence wait for {wait_entity} timed out, so continuing sequence"
+                                )
+
                         else:
                             domain, service = str.split(command, "/")
-                            if "namespace" in parameters:
-                                ns = parameters["namespace"]
-                                del parameters["namespace"]
-                            else:
-                                ns = namespace
                             parameters["__name"] = entity_id
                             await self.AD.services.call_service(ns, domain, service, parameters)
                 if loop is not True:
@@ -118,3 +184,9 @@ class Sequences:
 
             if ephemeral_entity is True:
                 await self.AD.state.remove_entity("rules", entity_id)
+
+    #
+    # Placeholder for constraints
+    #
+    def list_constraints(self):
+        return []

--- a/appdaemon/sequences.py
+++ b/appdaemon/sequences.py
@@ -162,7 +162,7 @@ class Sequences:
                             state = parameters.get("state")
                             attribute = parameters.get("attribute")
                             duration = parameters.get("duration", 0)
-                            timeout = parameters.get("timeout")
+                            timeout = parameters.get("timeout", 15 * 60)
 
                             # now we create the wait entity object
                             entity_object = Entity(self.logger, self.AD, name, ns, wait_entity)

--- a/appdaemon/thread_async.py
+++ b/appdaemon/thread_async.py
@@ -37,7 +37,7 @@ class ThreadAsync:
                     function = args["function"]
                     myargs = args["args"]
                     mykwargs = args["kwargs"]
-                    asyncio.ensure_future(function(*myargs, **mykwargs))
+                    asyncio.create_task(function(*myargs, **mykwargs))
                     # self.logger.debug("calling task_done()")
                     # self.appq.task_done()
             except Exception:

--- a/appdaemon/utility_loop.py
+++ b/appdaemon/utility_loop.py
@@ -97,6 +97,7 @@ class Utility:
             # Register run_sequence service
             #
             self.AD.services.register_service("rules", "sequence", "run", self.AD.sequences.run_sequence_service)
+            self.AD.services.register_service("rules", "sequence", "cancel", self.AD.sequences.run_sequence_service)
 
             #
             # Register production_mode service

--- a/docs/AD_API_REFERENCE.rst
+++ b/docs/AD_API_REFERENCE.rst
@@ -245,6 +245,12 @@ Runs a predefined sequence. The `entity_id` arg with the sequence full-qualified
 
     >>> self.call_service("sequence/run", entity_id ="sequence.christmas_lights", namespace="rules")
 
+**sequence/cancel**
+
+Cancels a predefined sequence. The `entity_id` arg with the sequence full-qualified entity name is required.
+
+    >>> self.call_service("sequence/cancel", entity_id ="sequence.christmas_lights", namespace="rules")
+
 
 Threading
 ~~~~~~~~~

--- a/docs/APPGUIDE.rst
+++ b/docs/APPGUIDE.rst
@@ -2728,6 +2728,7 @@ Entities can be created in user defined namespaces, which will hold the state of
         - wait_state:
             entity_id: condition.living_room_window
             state: "closed"
+            timeout: 60 # defaults to 15 minutes
             namespace: rules
 
         - mqtt/publish:

--- a/docs/APPGUIDE.rst
+++ b/docs/APPGUIDE.rst
@@ -2664,13 +2664,34 @@ Sequences can be created that will loop forever by adding the value ``loop: True
     sequence:
       outside_motion_light:
         name: Outside Motion
-        loop; True
+        loop: True
         steps:
         - homeassistant/turn_on: {"entity_id": "light.outside", "brightness": 254}
         - sleep: 30
         - homeassistant/turn_off: {"entity_id": "light.outside"}
 
 This sequence once started will loop until either the sequence is canceled, the app is restarted or terminated, or AppDaemon is shutdown.
+
+Not only can the whole sequence be looped, but steps can be looped to if wanting to run a certain step multiple times.
+Below is an example of increasing the volume of a device 5 times with 0.5 interval
+
+.. code:: yaml
+
+    sequence:
+      setup_tv:
+        name: Setup TV
+        namespace: hass
+        steps:
+        - homeassistant/turn_on:
+            entity_id: switch.living_room_tv
+
+        - sleep: 30
+
+        - remote/send_command:
+            entity_id: roku.living_room
+            loop_step:
+                times: 5
+                interval: 0.5
 
 Defining a Sequence Call Namespace
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/APPGUIDE.rst
+++ b/docs/APPGUIDE.rst
@@ -2579,10 +2579,11 @@ Sequences
 
 AppDaemon supports `sequences` as a simple way of re-using predefined steps of commands. The initial usecase for sequences
 is to allow users to create scenes within AppDaemon, however they are useful for many other things. Sequences
-are fairly simple and allow the user to define 2 types of activity:
+are fairly simple and allow the user to define 3 types of activities:
 
 - A call_service command with arbitrary parameters
 - A configurable delay between steps.
+- Pause execution, until an entity has a certain state
 
 In the case of a scene, of course you would not want to use the delay, and would just list all the devices to be switched
 on or off, however, if you wanted a light to come on for 30 seconds, you could use a script to turn the light on,
@@ -2605,6 +2606,7 @@ An example of a simple sequence entry to create a couple of scenes might be:
     sequence:
       office_on:
         name: Office On
+        namespace: hass
         steps:
         - homeassistant/turn_on:
             entity_id: light.office_1
@@ -2674,13 +2676,14 @@ Defining a Sequence Call Namespace
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 By default, a sequence will run on entities in the current namespace, however , the namespace can be specified on a per call
-basis if required.
+basis if required. Also it can be specifed at the top tier level, allowing for all service calls in the sequence to use the same namespace
 
 .. code:: yaml
 
     sequence:
       office_on:
         name: Office On
+        namespace: hass
         steps:
         - homeassistant/turn_on:
             entity_id: light.office_1
@@ -2703,6 +2706,33 @@ In addition to a straightforward service name plus data, sequences can take a fe
 - sequence - run a sub sequence. This must be a predefined sequence, and cannot be an inline sequence. Provide the entity
 name of the sub-sequence to be run, e.g. `sequence: sequcene.my_sub_sequence`. Sub sequences can be nested arbitrarily
 to any desired level.
+
+Sequence Wait State
+~~~~~~~~~~~~~~~~~~~
+
+In addition to a straightforward service name plus data, sequences can paused, to continue after an entity's state is a condition.
+This allows formore powerful use of sequence calls, for example you want to turn activate the conditioner, only after the window has been shut.
+Entities can be created in user defined namespaces, which will hold the state of conditions of interest and the sequence made to make use of the entity.
+
+.. code:: yaml
+
+    sequence:
+      air_condition_on:
+        name: Air Con On
+        namespace: mqtt
+        steps:
+        - mqtt/publish:
+            topic: "hermes/tts"
+            payload: "Turning on the AirCon, ensure windows are shut"
+
+        - wait_state:
+            entity_id: condition.living_room_window
+            state: "closed"
+            namespace: rules
+
+        - mqtt/publish:
+            topic: "air_condition/state"
+            payload: "on"
 
 Running a Sequence
 ~~~~~~~~~~~~~~~~~~

--- a/docs/HISTORY.rst
+++ b/docs/HISTORY.rst
@@ -10,7 +10,6 @@ Change Log
 - Added support for passing a list of entities to `listen_state` api
 - Clicking on a sequence name in AUI will now run the sequence
 - Added support for entity class alongeside `get_entity` and `get_entity_api` functions
-- Added support for entity class
 - Added the `wait_state` command for sequences, so a sequence can be paused until an entity or its attribute has a certain state
 - Added the `sequence/cancel` service call. So sequences can be cancelled
 - Added the ability to specify a high level namespace in sequence, so no need specifying per command

--- a/docs/HISTORY.rst
+++ b/docs/HISTORY.rst
@@ -14,6 +14,7 @@ Change Log
 - Added the `wait_state` command for sequences, so a sequence can be paused until an entity or its attribute has a certain state
 - Added the `sequence/cancel` service call. So sequences can be cancelled
 - Added the ability to specify a high level namespace in sequence, so no need specifying per command
+- Allowed for running or cancelling sequences using either entity_id or the sequences name
 
 **Fixes**
 
@@ -23,6 +24,7 @@ Change Log
 - Fix for Hass services not being captured after startup again
 - Fixed issue whereby `.git` paths where being imported into AD and leading to lots of unnecessary messages.
 - Fixed issue with AD being unable to refresh Plugin's entities
+- Fixed issue with using the `loop` in sequences for certain services
 - Documentation fixes - contributed by `markwmuller <https://github.com/markwmuller>`__
 - Documentation fixes - contributed by `JonasPed <https://github.com/JonasPed>`__
 - Documentation fixes - contributed by `elandt <https://github.com/elandt>`__

--- a/docs/HISTORY.rst
+++ b/docs/HISTORY.rst
@@ -10,6 +10,9 @@ Change Log
 - Added support for passing a list of entities to `listen_state` api
 - Clicking on a sequence name in AUI will now run the sequence
 - Added support for entity class
+- Added the `wait_state` command for sequences, so a sequence can be paused until an entity or its attribute has a certain state
+- Added the `sequence/cancel` service call. So sequences can be cancelled
+- Added the ability to specify a high level namespace in sequence, so no need specifying per command
 
 **Fixes**
 


### PR DESCRIPTION
This PR adds the following features
- Adds the ability for sequences to be paused using the `wait_state` command. So it only continues after the state/attribute of an entity is valid
- Adds the `sequence/cancel` service call
- Adds the ability to define a top tier namespace, just for those services in a configuration, will still retaining the ability to define at lower tiers
- Adds the ability to loop a certain step a number of times with certain delays within loop, by adding `loop_step` to the steps