### PR TITLE
Allow for reloading of app's module when a global module dependency reloads

### DIFF
--- a/docs/HISTORY.rst
+++ b/docs/HISTORY.rst
@@ -12,6 +12,7 @@ None
 
 - Fixed issue when when using `timeout` in listen event api, after the event is ran one gets an error in log
 - Fixed issue when an entity is deleted from HA, and it remains in AD
+- Fixed isue whereby when an app's global module dependency reloads, the app's module doesn't reload also
 
 **Breaking Changes**
 


### PR DESCRIPTION
In AD, when an app's `global_dependency` module reloads, the app's module doesn't automatically reload
This many a times is not an issue, if the module is used or instantiated within the `initialize` function.
But if the module's function is used outside the app's class like as a decorator or standalone function to be passed to another processor, the app never gets access to the latest update since the app's module never reloaded.

So this PR will ensure that when the `global_module` reloads, so also does the app's module reload.
This will also ensure that other apps, though using the same module that got reloaded will not restart and will continue to function. But they will only get the latest update, when the apps reloads themselves 