### PR TITLE
Fix register_route documentation

### DIFF
--- a/appdaemon/adapi.py
+++ b/appdaemon/adapi.py
@@ -1215,7 +1215,7 @@ class ADAPI:
             >>>   self.register_route(my_callback)
             >>>   self.register_route(stream_cb, "camera")
             >>>
-            >>> def camera(self, request, kwargs):
+            >>> async def camera(self, request, kwargs):
             >>>   return web.Response(text="test", content_type="text/html")
             
 

--- a/appdaemon/adapi.py
+++ b/appdaemon/adapi.py
@@ -1207,12 +1207,17 @@ class ADAPI:
             A handle that can be used to remove the registration.
 
         Examples:
-            It should be noted that the register function, should return a string (can be empty),
-            and an HTTP OK status response (e.g., `200`. If this is not added as a returned response,
-            the function will generate an error each time it is processed.
+            It should be noted that the register function, should return a aiohttp Response.
 
-            >>> self.register_route(my_callback)
-            >>> self.register_route(stream_cb, "camera")
+            >>> from aiohttp import web
+            
+            >>> def initialize(self):
+            >>>   self.register_route(my_callback)
+            >>>   self.register_route(stream_cb, "camera")
+            >>>
+            >>> def camera(self, request, kwargs):
+            >>>   return web.Response(text="test", content_type="text/html")
+            
 
         """
         if route is None:


### PR DESCRIPTION
Fix `register_route` document which needs to return an aiohttp Response object.

As per the response in this issue: https://github.com/AppDaemon/appdaemon/issues/1492