### PR TITLE
Container improvements

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,7 +4,15 @@
 Dockerfile
 .dockerignore
 
+azure-pipelines.yml
+.pre-commit-config.yaml
+.semaphore
+
 *.md
 !README*.md
+MANIFEST.in
+setup.py
 *.rst
+
 docs
+conf

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 .git
 .gitignore
+.github
 
 Dockerfile
 .dockerignore
@@ -16,3 +17,4 @@ setup.py
 
 docs
 conf
+.readthedocs.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,9 @@ VOLUME /certs
 WORKDIR /usr/src/app
 
 # Install runtime required packages
-RUN apk add --no-cache curl python3 py3-pip tzdata
+# First line is required, 2nd line is for backwards compatibility
+RUN apk add --no-cache curl python3 py3-pip tzdata \
+        git py3-wheel build-base gcc libffi-dev openssl-dev musl-dev cargo
 
 # Copy compiled deps from builder image
 COPY --from=builder /usr/lib/python3.9/site-packages/ /usr/lib/python3.9/site-packages/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG IMAGE=alpine:3.15
+ARG IMAGE=alpine:3.17
 FROM ${IMAGE} as builder
 
 WORKDIR /build
@@ -34,7 +34,7 @@ RUN apk add --no-cache curl python3 py3-pip tzdata \
         git py3-wheel build-base gcc libffi-dev openssl-dev musl-dev cargo
 
 # Copy compiled deps from builder image
-COPY --from=builder /usr/lib/python3.9/site-packages/ /usr/lib/python3.9/site-packages/
+COPY --from=builder /usr/lib/python3.10/site-packages/ /usr/lib/python3.10/site-packages/
 
 # Copy appdaemon into image
 COPY . .

--- a/dockerStart.sh
+++ b/dockerStart.sh
@@ -85,4 +85,4 @@ apk add --no-cache $(find $CONF -name system_packages.txt | xargs cat | tr '\n' 
 find $CONF -name requirements.txt -exec pip3 install --upgrade -r {} \;
 
 # Lets run it!
-exec appdaemon -c $CONF "$@"
+exec python3 -m appdaemon -c $CONF "$@"


### PR DESCRIPTION
Provides two major benefits:
- Reduced image size to ~285Mb
- Now compatible with alpine's py3-* packages

Has the downside that this is potentially a breaking change for some people - the final image no longer contains rust/gcc, so if anybody is running any additional requirements that need those, they'd need to add them back through system_requirements.txt. This is mitigated somewhat by the fact that they might just be able to add an alpine package for it (I did this work for scikit-learn, which takes ~20 minutes to compile on my low-power i3 server, vs 20 seconds to install the alpine package + deps). That still requires a config change for people though, so I understand if you won't want to merge this. I'd be willing to add those packages back in to this PR if you'd prefer.