### PR TITLE
Update basetemperature.js

### DIFF
--- a/appdaemon/widgets/basetemperature/basetemperature.js
+++ b/appdaemon/widgets/basetemperature/basetemperature.js
@@ -78,12 +78,7 @@ function basetemperature(widget_id, url, skin, parameters)
             minorTicks: 2,
             strokeTicks: true
         });
-        // self.gauge.value = state.state
-        // update so the red bar is current after a dashboard compile
-        if (self.parameters.settings.value == null)
-        {
-            self.parameters.settings.value = state.state
-        }
+        self.gauge.value = state.state
         self.gauge.update(self.parameters.settings)
     }
 }

--- a/appdaemon/widgets/basetemperature/basetemperature.js
+++ b/appdaemon/widgets/basetemperature/basetemperature.js
@@ -78,7 +78,13 @@ function basetemperature(widget_id, url, skin, parameters)
             minorTicks: 2,
             strokeTicks: true
         });
-        self.gauge.value = state.state
+        
+        // self.gauge.value = state.state
+        // update so the red bar is current after a dashboard compile
+        
+        if ( null == self.parameters.settings.value ){
+            self.parameters.settings.value = state.state
+        }
         self.gauge.update(self.parameters.settings)
     }
 }

--- a/appdaemon/widgets/basetemperature/basetemperature.js
+++ b/appdaemon/widgets/basetemperature/basetemperature.js
@@ -80,7 +80,8 @@ function basetemperature(widget_id, url, skin, parameters)
         });
         // self.gauge.value = state.state
         // update so the red bar is current after a dashboard compile
-        if (null == self.parameters.settings.value){
+        if (null == self.parameters.settings.value)
+        {
             self.parameters.settings.value = state.state
         }
         self.gauge.update(self.parameters.settings)

--- a/appdaemon/widgets/basetemperature/basetemperature.js
+++ b/appdaemon/widgets/basetemperature/basetemperature.js
@@ -78,7 +78,11 @@ function basetemperature(widget_id, url, skin, parameters)
             minorTicks: 2,
             strokeTicks: true
         });
-        self.gauge.value = state.state
+        // self.gauge.value = state.state
+        // update so the red bar is current after a dashboard compile
+        if (null == self.parameters.settings.value){
+            self.parameters.settings.value = state.state
+        }
         self.gauge.update(self.parameters.settings)
     }
 }

--- a/appdaemon/widgets/basetemperature/basetemperature.js
+++ b/appdaemon/widgets/basetemperature/basetemperature.js
@@ -80,7 +80,7 @@ function basetemperature(widget_id, url, skin, parameters)
         });
         // self.gauge.value = state.state
         // update so the red bar is current after a dashboard compile
-        if (null == self.parameters.settings.value)
+        if (self.parameters.settings.value == null)
         {
             self.parameters.settings.value = state.state
         }


### PR DESCRIPTION
When the temperature widget is first displayed, the red bar is always at the minimum temperature, not the current temperature. If the page is left alone long enough, it updates to the current temperature. But navigation to another page and returning causes it to reset to the minimum temperature. This change causes it to display the red bar at the current temperature even the first time. This is all assuming that the call to self.gauge.update(self.parameters.settings) is correct here.