### PR TITLE
Update basetemperature.js

### DIFF
--- a/appdaemon/widgets/basetemperature/basetemperature.js
+++ b/appdaemon/widgets/basetemperature/basetemperature.js
@@ -78,7 +78,12 @@ function basetemperature(widget_id, url, skin, parameters)
             minorTicks: 2,
             strokeTicks: true
         });
-        self.gauge.value = state.state
+        // self.gauge.value = state.state
+        // update so the red bar is current after a dashboard compile
+
+        if ( null == self.parameters.settings.value ){
+            self.parameters.settings.value = state.state
+        }
         self.gauge.update(self.parameters.settings)
     }
 }


### PR DESCRIPTION
When the dashboard is freshly compiled, the current temperature bar is set at the minimum temperature, not the current temperature. This change sets the current temperature bar to current temperature if it hasn't been set yet. All this assumes that the call to self.gauge.update at the end is correct.