### PR TITLE
refactor repeated SSL/auth cruft for HASS connection

### DIFF
--- a/appdaemon/.vscode/settings.json
+++ b/appdaemon/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "python.formatting.provider": "black"
-}

--- a/appdaemon/.vscode/settings.json
+++ b/appdaemon/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.formatting.provider": "black"
+}

--- a/appdaemon/plugins/hass/hassplugin.py
+++ b/appdaemon/plugins/hass/hassplugin.py
@@ -42,76 +42,41 @@ class HassPlugin(PluginBase):
         self.config = args
         self.name = name
 
-        self.stopping = False
-        self.ws = None
-        self.reading_messages = False
-        self.metadata = None
-        self.hass_booting = False
-
         self.logger.info("HASS Plugin Initializing")
 
-        self.name = name
-
-        if "namespace" in args:
-            self.namespace = args["namespace"]
-        else:
-            self.namespace = "default"
-
+        # validate basic config
         if "ha_key" in args:
-            self.ha_key = args["ha_key"]
             self.logger.warning("ha_key is deprecated please use HASS Long Lived Tokens instead")
-        else:
-            self.ha_key = None
-
-        if "token" in args:
-            self.token = args["token"]
-        else:
-            self.token = None
-
-        if "ha_url" in args:
-            self.ha_url = args["ha_url"]
-        else:
+        if "ha_url" not in args:
             self.logger.warning("ha_url not found in HASS configuration - module not initialized")
 
-        if "cert_path" in args:
-            self.cert_path = args["cert_path"]
-        else:
-            self.cert_path = None
+        # Locally store common args and their defaults
+        self.appdaemon_startup_conditions = args.get("appdaemon_startup_conditions", {})
+        self.cert_path = args.get("cert_path")
+        self.cert_verify = args.get("cert_verify")
+        self.commtype = args.get("commtype", "WS")
+        self.ha_key = args.get("ha_key")
+        self.ha_url = args.get("ha_url", "")
+        self.namespace = args.get("namespace", "default")
+        self.plugin_startup_conditions = args.get("plugin_startup_conditions", {})
+        self.retry_secs = int(args.get("retry_secs", 5))
+        self.timeout = args.get("timeout")
+        self.token = args.get("token")
 
-        if "timeout" in args:
-            self.timeout = args["timeout"]
-        else:
-            self.timeout = None
+        # Connections to HA
+        self._session = None  # http connection pool for general use
+        self.ws = None  # websocket dedicated for event loop
 
-        if "retry_secs" in args:
-            self.retry_secs = int(args["retry_secs"])
-        else:
-            self.retry_secs = 5
-
-        if "cert_verify" in args:
-            self.cert_verify = args["cert_verify"]
-        else:
-            self.cert_verify = True
-
-        if "commtype" in args:
-            self.commtype = args["commtype"]
-        else:
-            self.commtype = "WS"
-
-        if "appdaemon_startup_conditions" in args:
-            self.appdaemon_startup_conditions = args["appdaemon_startup_conditions"]
-        else:
-            self.appdaemon_startup_conditions = {}
-
-        if "plugin_startup_conditions" in args:
-            self.plugin_startup_conditions = args["plugin_startup_conditions"]
-        else:
-            self.plugin_startup_conditions = {}
-
-        self.session = None
-        self.first_time = False
-        self.already_notified = False
+        # Cached state from HA
+        self.metadata = None
         self.services = None
+
+        # Internal state flags
+        self.already_notified = False
+        self.first_time = False
+        self.hass_booting = False
+        self.reading_messages = False
+        self.stopping = False
 
         self.logger.info("HASS Plugin initialization complete")
 
@@ -131,9 +96,36 @@ class HassPlugin(PluginBase):
         return []
 
     #
+    # Persistent Session to HASS instance  
+    #
+    @property
+    def session(self):
+        if not self._session:
+            # ssl None means to use default behavior which check certs for https
+            ssl_context = (self.cert_verify and None)
+            if self.cert_verify and self.cert_path:
+                ssl_context = ssl.create_default_context(capath=self.cert_path)
+            conn = aiohttp.TCPConnector(ssl=ssl_context)
+
+            # configure auth
+            headers = {}
+            if self.token is not None:
+                headers["Authorization"] = "Bearer {}".format(self.token)
+            elif self.ha_key is not None:
+                headers["x-ha-access"] = self.ha_key
+
+            self._session = aiohttp.ClientSession(
+                base_url=self.ha_url,
+                connector=conn,
+                headers=headers,
+                json_serialize=utils.convert_json
+            )
+        return self._session
+
+
+    #
     # Get initial state
     #
-
     async def get_complete_state(self):
 
         hass_state = await self.get_hass_state()
@@ -147,14 +139,12 @@ class HassPlugin(PluginBase):
     #
     # Get HASS Metadata
     #
-
     async def get_metadata(self):
         return self.metadata
 
     #
     # Handle state updates
     #
-
     async def evaluate_started(self, first_time, plugin_booting, event=None):  # noqa: C901
 
         if first_time is True:
@@ -448,22 +438,11 @@ class HassPlugin(PluginBase):
         self.logger.debug("set_plugin_state() %s %s %s", namespace, entity_id, kwargs)
         config = (await self.AD.plugins.get_plugin_object(namespace)).config
 
-        # TODO cert_path is not used
-        if "cert_path" in config:
-            cert_path = config["cert_path"]
-        else:
-            cert_path = False  # noqa: F841
 
-        if "token" in config:
-            headers = {"Authorization": "Bearer {}".format(config["token"])}
-        elif "ha_key" in config:
-            headers = {"x-ha-access": config["ha_key"]}
-        else:
-            headers = {}
-        api_url = "{}/api/states/{}".format(config["ha_url"], entity_id)
+        api_url = "/api/states/{}".format(entity_id)
 
         try:
-            r = await self.session.post(api_url, headers=headers, json=kwargs, verify_ssl=self.cert_verify)
+            r = await self.session.post(api_url, json=kwargs)
             if r.status == 200 or r.status == 201:
                 state = await r.json()
                 self.logger.debug("return = %s", state)
@@ -508,25 +487,19 @@ class HassPlugin(PluginBase):
             data = {"entity_id": data}
 
         config = (await self.AD.plugins.get_plugin_object(namespace)).config
-        if "token" in config:
-            headers = {"Authorization": "Bearer {}".format(config["token"])}
-        elif "ha_key" in config:
-            headers = {"x-ha-access": config["ha_key"]}
-        else:
-            headers = {}
 
         if domain == "template" and service == "render":
-            api_url = "{}/api/template".format(config["ha_url"])
+            api_url = "/api/template"
 
         elif domain == "database":
             return await self.get_history(**data)
 
         else:
-            api_url = "{}/api/services/{}/{}".format(config["ha_url"], domain, service)
+            api_url = "/api/services/{}/{}".format(domain, service)
 
         try:
 
-            r = await self.session.post(api_url, headers=headers, json=data, verify_ssl=self.cert_verify)
+            r = await self.session.post(api_url, json=data)
 
             if r.status == 200 or r.status == 201:
                 if domain == "template":
@@ -567,23 +540,10 @@ class HassPlugin(PluginBase):
     async def get_history(self, **kwargs):
         """Used to get HA's History"""
 
-        # TODO cert_path is not used
-        if "cert_path" in self.config:
-            cert_path = self.config["cert_path"]
-        else:
-            cert_path = False  # noqa: F841
-
-        if "token" in self.config:
-            headers = {"Authorization": "Bearer {}".format(self.config["token"])}
-        elif "ha_key" in self.config:
-            headers = {"x-ha-access": self.config["ha_key"]}
-        else:
-            headers = {}
-
         try:
             api_url = await self.get_history_api(**kwargs)
 
-            r = await self.session.get(api_url, headers=headers, verify_ssl=self.cert_verify)
+            r = await self.session.get(api_url)
 
             if r.status == 200 or r.status == 201:
                 result = await r.json()
@@ -651,7 +611,7 @@ class HassPlugin(PluginBase):
 
         # Build the url
         # /api/history/period/<start_time>?filter_entity_id=<entity_id>&end_time=<end_time>
-        apiurl = f'{self.config["ha_url"]}/api/history/period'
+        apiurl = "/api/history/period"
 
         if start_time:
             apiurl += "/" + utils.dt_to_str(start_time.replace(microsecond=0), self.AD.tz)
@@ -667,19 +627,12 @@ class HassPlugin(PluginBase):
 
     async def get_hass_state(self, entity_id=None):
 
-        if self.token is not None:
-            headers = {"Authorization": "Bearer {}".format(self.token)}
-        elif self.ha_key is not None:
-            headers = {"x-ha-access": self.ha_key}
-        else:
-            headers = {}
-
         if entity_id is None:
-            api_url = "{}/api/states".format(self.ha_url)
+            api_url = "/api/states"
         else:
-            api_url = "{}/api/states/{}".format(self.ha_url, entity_id)
+            api_url = "/api/states/{}".format(entity_id)
         self.logger.debug("get_ha_state: url is %s", api_url)
-        r = await self.session.get(api_url, headers=headers, verify_ssl=self.cert_verify)
+        r = await self.session.get(api_url)
         if r.status == 200 or r.status == 201:
             state = await r.json()
         else:
@@ -720,24 +673,10 @@ class HassPlugin(PluginBase):
 
     async def get_hass_config(self):
         try:
-            if self.session is None:
-                #
-                # Set up HTTP Client
-                #
-                conn = aiohttp.TCPConnector()
-                self.session = aiohttp.ClientSession(connector=conn, json_serialize=utils.convert_json)
-
             self.logger.debug("get_ha_config()")
-            if self.token is not None:
-                headers = {"Authorization": "Bearer {}".format(self.token)}
-            elif self.ha_key is not None:
-                headers = {"x-ha-access": self.ha_key}
-            else:
-                headers = {}
-
-            api_url = "{}/api/config".format(self.ha_url)
+            api_url = "/api/config"
             self.logger.debug("get_ha_config: url is %s", api_url)
-            r = await self.session.get(api_url, headers=headers, verify_ssl=self.cert_verify)
+            r = await self.session.get(api_url)
             r.raise_for_status()
             meta = await r.json()
             #
@@ -749,23 +688,17 @@ class HassPlugin(PluginBase):
             self.validate_tz(meta)
 
             return meta
-        except Exception:
-            self.logger.warning("Error getting metadata - retrying")
+        except Exception as ex:
+            self.logger.warning("Error getting metadata - retrying: %s", str(ex))
             raise
 
     async def get_hass_services(self) -> dict:
         try:
             self.logger.debug("get_hass_services()")
-            if self.token is not None:
-                headers = {"Authorization": "Bearer {}".format(self.token)}
-            elif self.ha_key is not None:
-                headers = {"x-ha-access": self.ha_key}
-            else:
-                headers = {}
 
-            api_url = "{}/api/services".format(self.ha_url)
+            api_url = "/api/services"
             self.logger.debug("get_hass_services: url is %s", api_url)
-            r = await self.session.get(api_url, headers=headers, verify_ssl=self.cert_verify)
+            r = await self.session.get(api_url)
             r.raise_for_status()
             services = await r.json()
 
@@ -859,19 +792,13 @@ class HassPlugin(PluginBase):
     async def fire_plugin_event(self, event, namespace, **kwargs):
         self.logger.debug("fire_event: %s, %s %s", event, namespace, kwargs)
 
-        config = (await self.AD.plugins.get_plugin_object(namespace)).config
-
-        if "token" in config:
-            headers = {"Authorization": "Bearer {}".format(config["token"])}
-        elif "ha_key" in config:
-            headers = {"x-ha-access": config["ha_key"]}
-        else:
-            headers = {}
+        # if we get a request for not our namespace something has gone very wrong
+        assert namespace == self.namespace
 
         event_clean = quote(event, safe="")
-        api_url = "{}/api/events/{}".format(config["ha_url"], event_clean)
+        api_url = "/api/events/{}".format(event_clean)
         try:
-            r = await self.session.post(api_url, headers=headers, json=kwargs, verify_ssl=self.cert_verify)
+            r = await self.session.post(api_url, json=kwargs)
             r.raise_for_status()
             state = await r.json()
             return state
@@ -890,25 +817,14 @@ class HassPlugin(PluginBase):
     @hass_check
     async def remove_entity(self, namespace, entity_id):
         self.logger.debug("remove_entity() %s", entity_id)
-        config = (await self.AD.plugins.get_plugin_object(namespace)).config
 
-        # TODO cert_path is not used
-        if "cert_path" in config:
-            cert_path = config["cert_path"]
-        else:
-            cert_path = False  # noqa: F841
+        # if we get a request for not our namespace something has gone very wrong
+        assert namespace == self.namespace
 
-        if "token" in config:
-            headers = {"Authorization": "Bearer {}".format(config["token"])}
-        elif "ha_key" in config:
-            headers = {"x-ha-access": config["ha_key"]}
-        else:
-            headers = {}
-
-        api_url = "{}/api/states/{}".format(config["ha_url"], entity_id)
+        api_url = "/api/states/{}".format(entity_id)
 
         try:
-            r = await self.session.delete(api_url, headers=headers, verify_ssl=self.cert_verify)
+            r = await self.session.delete(api_url)
             if r.status == 200 or r.status == 201:
                 state = await r.json()
                 self.logger.debug("return = %s", state)

--- a/appdaemon/plugins/hass/hassplugin.py
+++ b/appdaemon/plugins/hass/hassplugin.py
@@ -25,7 +25,9 @@ def hass_check(func):
     def func_wrapper(*args, **kwargs):
         self = args[0]
         if not self.reading_messages:
-            self.logger.warning("Attempt to call Home Assistant while disconnected: %s", func.__name__)
+            self.logger.warning(
+                "Attempt to call Home Assistant while disconnected: %s", func.__name__
+            )
             return no_func()
         else:
             return func(*args, **kwargs)
@@ -46,9 +48,13 @@ class HassPlugin(PluginBase):
 
         # validate basic config
         if "ha_key" in args:
-            self.logger.warning("ha_key is deprecated please use HASS Long Lived Tokens instead")
+            self.logger.warning(
+                "ha_key is deprecated please use HASS Long Lived Tokens instead"
+            )
         if "ha_url" not in args:
-            self.logger.warning("ha_url not found in HASS configuration - module not initialized")
+            self.logger.warning(
+                "ha_url not found in HASS configuration - module not initialized"
+            )
 
         # Locally store common args and their defaults
         self.appdaemon_startup_conditions = args.get("appdaemon_startup_conditions", {})
@@ -96,13 +102,13 @@ class HassPlugin(PluginBase):
         return []
 
     #
-    # Persistent Session to HASS instance  
+    # Persistent Session to HASS instance
     #
     @property
     def session(self):
         if not self._session:
             # ssl None means to use default behavior which check certs for https
-            ssl_context = (self.cert_verify and None)
+            ssl_context = None if self.cert_verify else False
             if self.cert_verify and self.cert_path:
                 ssl_context = ssl.create_default_context(capath=self.cert_path)
             conn = aiohttp.TCPConnector(ssl=ssl_context)
@@ -118,10 +124,9 @@ class HassPlugin(PluginBase):
                 base_url=self.ha_url,
                 connector=conn,
                 headers=headers,
-                json_serialize=utils.convert_json
+                json_serialize=utils.convert_json,
             )
         return self._session
-
 
     #
     # Get initial state
@@ -145,7 +150,9 @@ class HassPlugin(PluginBase):
     #
     # Handle state updates
     #
-    async def evaluate_started(self, first_time, plugin_booting, event=None):  # noqa: C901
+    async def evaluate_started(
+        self, first_time, plugin_booting, event=None
+    ):  # noqa: C901
 
         if first_time is True:
             self.hass_ready = False
@@ -163,7 +170,9 @@ class HassPlugin(PluginBase):
 
         if "delay" in startup_conditions:
             if first_time is True:
-                self.logger.info("Delaying startup for %s seconds", startup_conditions["delay"])
+                self.logger.info(
+                    "Delaying startup for %s seconds", startup_conditions["delay"]
+                )
                 await asyncio.sleep(int(startup_conditions["delay"]))
 
         if "hass_state" in startup_conditions:
@@ -196,7 +205,9 @@ class HassPlugin(PluginBase):
                     start_ok = False
             elif entry["entity"] in state:
                 if self.state_matched is False:
-                    self.logger.info("Startup condition met: %s exists", entry["entity"])
+                    self.logger.info(
+                        "Startup condition met: %s exists", entry["entity"]
+                    )
                     self.state_matched = True
                 else:
                     start_ok = False
@@ -214,7 +225,9 @@ class HassPlugin(PluginBase):
                         start_ok = False
                 else:
                     if entry["event_type"] == event["event_type"]:
-                        if "values_changed" not in DeepDiff(event["data"], entry["data"]):
+                        if "values_changed" not in DeepDiff(
+                            event["data"], entry["data"]
+                        ):
                             self.logger.info(
                                 "Startup condition met: event type %s, data = %s fired",
                                 event["event_type"],
@@ -294,7 +307,9 @@ class HassPlugin(PluginBase):
                     sslopt = {"cert_reqs": ssl.CERT_NONE}
                 if self.cert_path:
                     sslopt["ca_certs"] = self.cert_path
-                self.ws = websocket.create_connection("{}/api/websocket".format(url), sslopt=sslopt)
+                self.ws = websocket.create_connection(
+                    "{}/api/websocket".format(url), sslopt=sslopt
+                )
                 res = await utils.run_in_executor(self, self.ws.recv)
                 result = json.loads(res)
                 self.logger.info("Connected to Home Assistant %s", result["ha_version"])
@@ -307,7 +322,9 @@ class HassPlugin(PluginBase):
                     elif self.ha_key is not None:
                         auth = json.dumps({"type": "auth", "api_password": self.ha_key})
                     else:
-                        raise ValueError("HASS requires authentication and none provided in plugin config")
+                        raise ValueError(
+                            "HASS requires authentication and none provided in plugin config"
+                        )
 
                     await utils.run_in_executor(self, self.ws.send, auth)
                     result = json.loads(self.ws.recv())
@@ -320,8 +337,14 @@ class HassPlugin(PluginBase):
                 sub = json.dumps({"id": _id, "type": "subscribe_events"})
                 await utils.run_in_executor(self, self.ws.send, sub)
                 result = json.loads(self.ws.recv())
-                if not (result["id"] == _id and result["type"] == "result" and result["success"] is True):
-                    self.logger.warning("Unable to subscribe to HA events, id = %s", _id)
+                if not (
+                    result["id"] == _id
+                    and result["type"] == "result"
+                    and result["success"] is True
+                ):
+                    self.logger.warning(
+                        "Unable to subscribe to HA events, id = %s", _id
+                    )
                     self.logger.warning(result)
                     raise ValueError("Error subscribing to HA Events")
 
@@ -337,7 +360,11 @@ class HassPlugin(PluginBase):
                     domain = hass_service["domain"]
                     for service in hass_service["services"]:
                         self.AD.services.register_service(
-                            self.get_namespace(), domain, service, self.call_plugin_service, __silent=True
+                            self.get_namespace(),
+                            domain,
+                            service,
+                            self.call_plugin_service,
+                            __silent=True,
                         )
 
                 # Decide if we can start yet
@@ -365,12 +392,16 @@ class HassPlugin(PluginBase):
                     result = json.loads(ret)
 
                     if not (result["id"] == _id and result["type"] == "event"):
-                        self.logger.warning("Unexpected result from Home Assistant, id = %s", _id)
+                        self.logger.warning(
+                            "Unexpected result from Home Assistant, id = %s", _id
+                        )
                         self.logger.warning(result)
 
                     if self.reading_messages is False:
                         if result["type"] == "event":
-                            await self.evaluate_started(False, self.hass_booting, result["event"])
+                            await self.evaluate_started(
+                                False, self.hass_booting, result["event"]
+                            )
                         else:
                             await self.evaluate_started(False, self.hass_booting)
                     else:
@@ -380,7 +411,9 @@ class HassPlugin(PluginBase):
                         metadata["context"] = result["event"].pop("context", None)
                         result["event"]["data"]["metadata"] = metadata
 
-                        await self.AD.events.process_event(self.namespace, result["event"])
+                        await self.AD.events.process_event(
+                            self.namespace, result["event"]
+                        )
 
                         if result["event"].get("event_type") == "service_registered":
                             data = result["event"]["data"]
@@ -401,10 +434,15 @@ class HassPlugin(PluginBase):
                 await self.AD.callbacks.clear_callbacks(self.name)
 
                 if not self.already_notified:
-                    await self.AD.plugins.notify_plugin_stopped(self.name, self.namespace)
+                    await self.AD.plugins.notify_plugin_stopped(
+                        self.name, self.namespace
+                    )
                     self.already_notified = True
                 if not self.stopping:
-                    self.logger.warning("Disconnected from Home Assistant, retrying in %s seconds", self.retry_secs)
+                    self.logger.warning(
+                        "Disconnected from Home Assistant, retrying in %s seconds",
+                        self.retry_secs,
+                    )
                     self.logger.debug("-" * 60)
                     self.logger.debug("Unexpected error:")
                     self.logger.debug("-" * 60)
@@ -459,7 +497,9 @@ class HassPlugin(PluginBase):
                 state = None
             return state
         except (asyncio.TimeoutError, asyncio.CancelledError):
-            self.logger.warning("Timeout in set_state(%s, %s, %s)", namespace, entity_id, kwargs)
+            self.logger.warning(
+                "Timeout in set_state(%s, %s, %s)", namespace, entity_id, kwargs
+            )
         except aiohttp.client_exceptions.ServerDisconnectedError:
             self.logger.warning("HASS Disconnected unexpectedly during set_state()")
         except Exception:
@@ -533,7 +573,9 @@ class HassPlugin(PluginBase):
         except Exception:
             self.logger.error("-" * 60)
             self.logger.error("Unexpected error during call_plugin_service()")
-            self.logger.error("Service: %s.%s.%s Arguments: %s", namespace, domain, service, data)
+            self.logger.error(
+                "Service: %s.%s.%s Arguments: %s", namespace, domain, service, data
+            )
             self.logger.error("-" * 60)
             self.logger.error(traceback.format_exc())
             self.logger.error("-" * 60)
@@ -616,7 +658,9 @@ class HassPlugin(PluginBase):
         apiurl = "/api/history/period"
 
         if start_time:
-            apiurl += "/" + utils.dt_to_str(start_time.replace(microsecond=0), self.AD.tz)
+            apiurl += "/" + utils.dt_to_str(
+                start_time.replace(microsecond=0), self.AD.tz
+            )
 
         if entity_id or end_time:
             if entity_id:
@@ -646,7 +690,9 @@ class HassPlugin(PluginBase):
 
     def validate_meta(self, meta, key):
         if key not in meta:
-            self.logger.warning("Value for '%s' not found in metadata for plugin %s", key, self.name)
+            self.logger.warning(
+                "Value for '%s' not found in metadata for plugin %s", key, self.name
+            )
             raise ValueError
         try:
             float(meta[key])
@@ -661,7 +707,9 @@ class HassPlugin(PluginBase):
 
     def validate_tz(self, meta):
         if "time_zone" not in meta:
-            self.logger.warning("Value for 'time_zone' not found in metadata for plugin %s", self.name)
+            self.logger.warning(
+                "Value for 'time_zone' not found in metadata for plugin %s", self.name
+            )
             raise ValueError
         try:
             pytz.timezone(meta["time_zone"])
@@ -751,7 +799,9 @@ class HassPlugin(PluginBase):
 
                 await self.check_register_service(domain, services)
 
-    async def check_register_service(self, domain: str, services: Union[dict, str]) -> bool:
+    async def check_register_service(
+        self, domain: str, services: Union[dict, str]
+    ) -> bool:
         """Used to check and register a service if need be"""
 
         domain_exists = False
@@ -775,7 +825,11 @@ class HassPlugin(PluginBase):
 
                 self.services[service_index]["services"][services] = {}
                 self.AD.services.register_service(
-                    self.get_namespace(), domain, services, self.call_plugin_service, __silent=True
+                    self.get_namespace(),
+                    domain,
+                    services,
+                    self.call_plugin_service,
+                    __silent=True,
                 )
 
         else:
@@ -785,7 +839,11 @@ class HassPlugin(PluginBase):
 
                     self.services[service_index]["services"][service] = service_data
                     self.AD.services.register_service(
-                        self.get_namespace(), domain, service, self.call_plugin_service, __silent=True
+                        self.get_namespace(),
+                        domain,
+                        service,
+                        self.call_plugin_service,
+                        __silent=True,
                     )
 
         return domain_exists
@@ -805,7 +863,9 @@ class HassPlugin(PluginBase):
             state = await r.json()
             return state
         except (asyncio.TimeoutError, asyncio.CancelledError):
-            self.logger.warning("Timeout in fire_event(%s, %s, %s)", event, namespace, kwargs)
+            self.logger.warning(
+                "Timeout in fire_event(%s, %s, %s)", event, namespace, kwargs
+            )
         except aiohttp.client_exceptions.ServerDisconnectedError:
             self.logger.warning("HASS Disconnected unexpectedly during fire_event()")
         except Exception:
@@ -831,13 +891,17 @@ class HassPlugin(PluginBase):
                 state = await r.json()
                 self.logger.debug("return = %s", state)
             else:
-                self.logger.warning("Error Removing Home Assistant entity %s", entity_id)
+                self.logger.warning(
+                    "Error Removing Home Assistant entity %s", entity_id
+                )
                 txt = await r.text()
                 self.logger.warning("Code: %s, error: %s", r.status, txt)
                 state = None
             return state
         except (asyncio.TimeoutError, asyncio.CancelledError):
-            self.logger.warning("Timeout in remove_entity(%s, %s)", namespace, entity_id)
+            self.logger.warning(
+                "Timeout in remove_entity(%s, %s)", namespace, entity_id
+            )
         except aiohttp.client_exceptions.ServerDisconnectedError:
             self.logger.warning("HASS Disconnected unexpectedly during remove_entity()")
         except Exception:

--- a/appdaemon/plugins/hass/hassplugin.py
+++ b/appdaemon/plugins/hass/hassplugin.py
@@ -436,8 +436,9 @@ class HassPlugin(PluginBase):
     @hass_check
     async def set_plugin_state(self, namespace, entity_id, **kwargs):
         self.logger.debug("set_plugin_state() %s %s %s", namespace, entity_id, kwargs)
-        config = (await self.AD.plugins.get_plugin_object(namespace)).config
 
+        # if we get a request for not our namespace something has gone very wrong
+        assert namespace == self.namespace
 
         api_url = "/api/states/{}".format(entity_id)
 
@@ -480,13 +481,14 @@ class HassPlugin(PluginBase):
             data,
         )
 
+        # if we get a request for not our namespace something has gone very wrong
+        assert namespace == self.namespace
+
         #
         # If data is a string just assume it's an entity_id
         #
         if isinstance(data, str):
             data = {"entity_id": data}
-
-        config = (await self.AD.plugins.get_plugin_object(namespace)).config
 
         if domain == "template" and service == "render":
             api_url = "/api/template"


### PR DESCRIPTION
This pulls all the copypasta auth and ssl handling into a single place for the aiohttp session, and as a bonus implements the todo around using the cert_path argument.  Additionally, put the ha_url into the session's base_url rather than prepending it everywhere.

With this change, now any appdaemon app can use `plugin.session.request("get", "/api/whatever")` to make arbitrary HA rest calls through the AD session, allowing full access to HA data even if there's no integrated AD support for it (like Devices or Areas or search).