### PR TITLE
Support entity.state in async contexts

### DIFF
--- a/appdaemon/entity.py
+++ b/appdaemon/entity.py
@@ -16,7 +16,9 @@ class EntityAttrs:
         pass
 
     def __get__(self, instance, owner):
-        stateattrs = utils.EntityStateAttrs(instance.get_state(attribute="all", copy=False, default={}))
+        # Get the state directly (not via get_state) to be able to use entity.states in both sync/async contexts
+
+        stateattrs = utils.EntityStateAttrs(instance.AD.state.state[instance.namespace][instance.entity_id])
         return stateattrs
 
 


### PR DESCRIPTION
This tiny change allows using `entity.state` in async functions (which is much nicer than writing `await entity.get_state()`). The problem is that `entity.state` is a sync operation, so we need to fetch the state directly instead of via `entity.get_state` (which is an async operation).

Maybe there's a better way to do it, but I thought a PR is the best way to start a discussion :smile: 

Closes #1605