### PR TITLE
Support Multiple Input Constraints

### DIFF
--- a/appdaemon/plugins/hass/hassapi.py
+++ b/appdaemon/plugins/hass/hassapi.py
@@ -310,15 +310,17 @@ class Hass(adbase.ADBase, adapi.ADAPI):
         unconstrained = True
         state = self.get_state()
 
-        values = value.split(",")
-        if len(values) == 2:
-            entity = values[0]
-            desired_state = values[1]
-        else:
-            entity = value
-            desired_state = "on"
-        if entity in state and state[entity]["state"] != desired_state:
-            unconstrained = False
+        constraints = [value] if isinstance(value, str) else value
+        for constraint in constraints:
+            values = constraint.split(",")
+            if len(values) == 2:
+                entity = values[0]
+                desired_state = values[1]
+            else:
+                entity = constraint
+                desired_state = "on"
+            if entity in state and state[entity]["state"] != desired_state:
+                unconstrained = False
 
         return unconstrained
 
@@ -326,10 +328,12 @@ class Hass(adbase.ADBase, adapi.ADAPI):
         unconstrained = True
         state = self.get_state()
 
-        values = value.split(",")
-        entity = values.pop(0)
-        if entity in state and state[entity]["state"] not in values:
-            unconstrained = False
+        constraints = [value] if isinstance(value, str) else value
+        for constraint in constraints:
+            values = constraint.split(",")
+            entity = values.pop(0)
+            if entity in state and state[entity]["state"] not in values:
+                unconstrained = False
 
         return unconstrained
 

--- a/docs/APPGUIDE.rst
+++ b/docs/APPGUIDE.rst
@@ -711,6 +711,18 @@ the input\_boolean is off, use the optional state parameter by appending,
       class: SomeClass
       constrain_input_boolean: input_boolean.enable_motion_detection,off
 
+If you want to constrain on multiple input_boolean entities, you can provide
+the constraints as a yaml list
+
+.. code:: yaml
+
+    some_app:
+      module: some_module
+      class: SomeClass
+      constrain_input_boolean:
+        - input_boolean.enable_motion_detection
+        - binary_sensor.weekend,off
+
 input\_select
 ^^^^^^^^^^^^^
 
@@ -725,6 +737,19 @@ according to some flag, e.g., a house mode flag.
     constrain_input_select: input_select.house_mode,Day
     # or multiple values
     constrain_input_select: input_select.house_mode,Day,Evening,Night
+
+
+If you want to constrain on multiple input_select entities, you can provide
+the constraints as a yaml list
+
+.. code:: yaml
+
+    some_app:
+      module: some_module
+      class: SomeClass
+      constrain_input_select:
+        - input_select.house_mode,Day
+        - sensor.day_of_week,Monday,Wednesday,Friday
 
 presence
 ^^^^^^^^


### PR DESCRIPTION
This small change allows users to configure multiple input_boolean or input_select constraints for their apps.

For example, with this change, users should be able to configure this app:
```yaml
workday_sunrise_alarm:
  module: lights
  class: SunriseAlarmLight
  light: light.bedroom
  rise_time: '07:00:00'
  constrain_input_boolean:
    - input_boolean.weekday_alarm_enabled
    - binary_sensor.is_weekday,off
  constrain_input_select:
    - person.me,home
    - person.partner,home
```