### PR TITLE
Add callable filtering for more complex filtering logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,4 @@ We use [pre-commit](https://pre-commit.com) for linting of the code, so `pip ins
 pre-commit install
 ```
 in the repository.
+

--- a/appdaemon/adapi.py
+++ b/appdaemon/adapi.py
@@ -1278,9 +1278,13 @@ class ADAPI:
                 state of the selected attribute (usually state) in the new state match the value
                 of ``new``. The parameter type is defined by the namespace or plugin that is responsible
                 for the entity. If it looks like a float, list, or dictionary, it may actually be a string.
+                If ``new`` is a callable (lambda, function, etc), then it will be invoked with the new state,
+                and if it returns ``True``, it will be considered to match.
             old (optional): If ``old`` is supplied as a parameter, callbacks will only be made if the
                 state of the selected attribute (usually state) in the old state match the value
                 of ``old``. The same caveats on types for the ``new`` parameter apply to this parameter.
+                If ``old`` is a callable (lambda, function, etc), then it will be invoked with the old state,
+                and if it returns a ``True``, it will be considered to match.
 
             duration (int, optional): If ``duration`` is supplied as a parameter, the callback will not
                 fire unless the state listened for is maintained for that number of seconds. This
@@ -1360,6 +1364,10 @@ class ADAPI:
             Listen for a state change involving `light.office1` turning on and return the state attribute.
 
             >>> self.handle = self.listen_state(self.my_callback, "light.office_1", new = "on")
+
+            Listen for a state change involving `light.office1` turning on when the previous state was not unknown or unavailable, and return the state attribute.
+
+            >>> self.handle = self.listen_state(self.my_callback, "light.office_1", new = "on", old=lambda x: x not in ["unknown", "unavailable"])
 
             Listen for a change involving `light.office1` changing from brightness 100 to 200 and return the
             brightness attribute.
@@ -1845,7 +1853,9 @@ class ADAPI:
             **kwargs (optional): One or more keyword value pairs representing App specific
                 parameters to supply to the callback. If the keywords match values within the
                 event data, they will act as filters, meaning that if they don't match the
-                values, the callback will not fire.
+                values, the callback will not fire. If the values provided are callable (lambda,
+                function, etc), then they'll be invoked with the events content, and if they return
+                ``True``, they'll be considered to match.
 
                 As an example of this, a `Minimote` controller when activated will generate
                 an event called zwave.scene_activated, along with 2 pieces of data that are
@@ -1874,6 +1884,10 @@ class ADAPI:
             Listen for a `minimote` event activating scene 3 from a specific `minimote`.
 
             >>> self.listen_event(self.generic_event, "zwave.scene_activated", entity_id = "minimote_31", scene_id = 3)
+
+            Listen for a `minimote` event activating scene 3 from certain `minimote`s (starting with 3), matched with code.
+
+            >>> self.listen_event(self.generic_event, "zwave.scene_activated", entity_id = lambda x: x.starts_with("minimote_3"), scene_id = 3)
 
             Listen for some custom events of a button being pressed.
 

--- a/appdaemon/events.py
+++ b/appdaemon/events.py
@@ -323,8 +323,15 @@ class Events:
 
                             _run = True
                             for key in callback["kwargs"]:
-                                if key in data["data"] and callback["kwargs"][key] != data["data"][key]:
-                                    _run = False
+                                if key in data["data"]:
+                                    event_val = data["data"][key]
+                                    match_val = callback["kwargs"][key]
+
+                                    if callable(match_val):
+                                        if match_val(event_val) is not True:
+                                            _run = False
+                                    elif match_val != event_val:
+                                        _run = False
 
                             if data["event_type"] == "__AD_LOG_EVENT":
                                 if (

--- a/appdaemon/threading.py
+++ b/appdaemon/threading.py
@@ -726,7 +726,9 @@ class Threading:
                 #
                 # Check if we care about the change
                 #
-                if (cold is None or cold == old) and (cnew is None or cnew == new):
+                if (cold is None or cold == old or (callable(cold) and cold(old) is True)) and (
+                    cnew is None or cnew == new or (callable(cnew) and cnew(new) is True)
+                ):
                     #
                     # We do!
                     #

--- a/docs/APPGUIDE.rst
+++ b/docs/APPGUIDE.rst
@@ -1612,7 +1612,8 @@ subscribe to all events.
 One or more keyword value pairs representing App specific parameters to
 supply to the callback. If the keywords match values within the event
 data, they will act as filters, meaning that if they don't match the
-values, the callback will not fire.
+values, the callback will not fire. If the values are callable, they will
+be invoked and if they return ``True`` they'll be considered a match.
 
 As an example of this, a Minimote controller when activated will
 generate an event called ``zwave_js_value_notification``, along with 2 pieces
@@ -1637,6 +1638,8 @@ Examples
     self.listen_event(self.generic_event, "zwave_js_value_notification", value = 3)
     # Listen for a minimote event activating scene 3 from a specific minimote:
     self.listen_event(self.generic_event, "zwave_js_value_notification", node_id = "11", value = 3)
+    # Listen for a minimote event activating scene 3 from one of several minimotes:
+    self.listen_event(self.generic_event, "zwave_js_value_notification", node_id = lambda x: x in ["11", "14", "22"], value = 3)
 
 Use of Events for Signalling between Home Assistant and AppDaemon
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Hello! Based on our discussion in https://github.com/AppDaemon/appdaemon/issues/1625, I realized that lifting some of my filtering much earlier in the appdaemon code would really improve performance. I've added this functionality for events and states, and I've also added documentation for it so that it's (hopefully) easier to merge. I also ran black to match the style.

This functionality is really useful for all kinds of situations. Some examples:
- If you want to use icloud3 trackers for state tracking, you need callbacks when a zone is entered (easy with the previous code) and when a zone exited (new state can be anything except a specific zone, easily expressed with a lambda)
- If you want to filter `call_service` events from homeassistant so that you can snoop on actions happening from other users/integrations, you probably only care about certain entities. For turning lights on & off, the light entity is either represented as {"domain": "light", "service": "turn_on", "service_data": {"entity_id": $ID, ...}, ...} or `{"domain": "light", "service": "turn_on", "service_data": {"entity_id": [$ID, ...], ...}, ...}`. It's much faster to filter these out before we trigger the event dispatching code.

I really hope you consider merging this, and I'd love to make any changes that make this more palatable. I'm already finding this to be a performance & expressiveness win.