### PR TITLE
Fix pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
   hooks:
     - id: end-of-file-fixer
     - id: trailing-whitespace
-- repo: https://gitlab.com/pycqa/flake8
+- repo: https://github.com/PyCQA/flake8
   rev: 3.7.8
   hooks:
     - id: flake8


### PR DESCRIPTION
I noticed that continuous integration seems to be broken. It looks like flake8 moved from gitlab to github. This works for me, now.