### PR TITLE
CI: automatic build

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/checkout@v3
       # https://github.com/actions/setup-python
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: "3.10"
           cache: 'pip' # caching pip dependencies

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -1,0 +1,96 @@
+# Build a docker image and Python package. If on `dev`` branch or git tag:
+#  - Deploy Docker image to Docker Hub
+#  - Deploy Python package to PyPi
+name: Build and deploy
+
+on:
+  push:
+    branches: ["dev"]
+    tags: ["*"]
+  pull_request:
+    branches: ["dev"]
+
+# Cancel a currently running workflow from the same PR, branch or tag when a new workflow is triggered:
+# Taken from https://stackoverflow.com/a/72408109
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  # github.repository as <account>/<repo>
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build_package:
+    name: Python package
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      # https://github.com/actions/setup-python
+      - name: Set up Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.10"
+          cache: 'pip' # caching pip dependencies
+          # Manually set pyproject.toml as the file to use for dependencies
+          # Workaround while waiting for https://github.com/actions/setup-python/issues/529
+          cache-dependency-path: 'pyproject.toml'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .[dev]
+      - name: Build Python package
+        run: python -m build
+
+      # Publish package only on Git tag
+      - name: Publish package
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}
+
+  build_image:
+    name: Docker image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Setup Docker buildx
+        uses: docker/setup-buildx-action@v2.4.1
+      # Login against a Docker registry (except on PR)
+      # https://github.com/docker/login-action
+      - name: Log into Docker Hub
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v2.1.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+      # Extract metadata (tags, labels) for Docker
+      # https://github.com/docker/metadata-action
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v4.3.0
+        with:
+          images: ${{ env.IMAGE_NAME }}
+      # Build and push Docker image with Buildx (don't push on PR)
+      # https://github.com/docker/build-push-action
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@v4.0.0
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/arm64/v8, linux/amd64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
Automatically build the Docker container and the Python package.

## Description
- On pull requests against `dev` -> build Python package and the Docker image, but don't publish them.
- When there is a push in the `dev` branch -> build Docker image with tag `dev`, deploy to Docker Hub
- When there is a git tag, build Docker image with tag taken from version + deploy to Docker Hub and PyPi.

## TODO
How to handle version numbering for the Python package? Should we use the Git tag to automatically infer the package version?
That way we don't have to manually update the `version.py` file every time we have a release, risking a mismatch between the tag and the version written inside if one forgets to keep them in sync.

## Requirements
Setup [Github secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets#about-encrypted-secrets) inside the repository settings with the credentials to authenticate against PyPI and Docker Hub
Secrets needed:
- PYPI_API_TOKEN [instructions on how to create API token](https://pypi.org/help/#apitoken)
- DOCKERHUB_USERNAME [instruction on how to create access token](https://pypi.org/help/#apitoken)
- DOCKERHUB_PASSWORD