### PR TITLE
CI: Optimize docker build

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -21,6 +21,7 @@ env:
   IMAGE_NAME: acockburn/appdaemon
 
 jobs:
+  # The Python package is required in the subsequent Docker image build
   build_package:
     name: Python package
     runs-on: ubuntu-latest
@@ -46,7 +47,11 @@ jobs:
           pip install -e .[dev]
       - name: Build Python package
         run: python -m build
-
+      - name: Upload Python package
+        uses: actions/upload-artifact@v3
+        with:
+          name: python-package
+          path: dist/
       # Publish package only on Git tag
       - name: Publish package
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
@@ -54,9 +59,11 @@ jobs:
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
 
+  # After building the Python package, build the Docker image
   build_image:
     name: Docker image
     runs-on: ubuntu-latest
+    needs: ['build_package']
     permissions:
       contents: read
       packages: write
@@ -64,6 +71,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+      - name: Download Python package
+        uses: actions/download-artifact@v3
+        with:
+          name: python-package
+          path: dist/
       - name: Setup Docker buildx
         uses: docker/setup-buildx-action@v2.4.1
       # Login against a Docker registry (only with a tag or push on `dev` branch)

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -5,7 +5,7 @@ name: Build and deploy
 
 on:
   push:
-    branches: ["dev"]
+    branches: ["**"]
     tags: ["*"]
   pull_request:
     branches: ["dev"]
@@ -66,10 +66,10 @@ jobs:
         uses: actions/checkout@v3
       - name: Setup Docker buildx
         uses: docker/setup-buildx-action@v2.4.1
-      # Login against a Docker registry (except on PR)
+      # Login against a Docker registry (only with a tag or push on `dev` branch)
       # https://github.com/docker/login-action
       - name: Log into Docker Hub
-        if: github.event_name != 'pull_request'
+        if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags') || github.ref_name == 'dev')
         uses: docker/login-action@v2.1.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -81,14 +81,14 @@ jobs:
         uses: docker/metadata-action@v4.3.0
         with:
           images: ${{ env.IMAGE_NAME }}
-      # Build and push Docker image with Buildx (don't push on PR)
+      # Build and push Docker image with Buildx (push image only with a tag or push on `dev` branch)
       # https://github.com/docker/build-push-action
       - name: Build and push Docker image
         id: build-and-push
         uses: docker/build-push-action@v4.0.0
         with:
           context: .
-          push: ${{ github.event_name != 'pull_request' }}
+          push: ${{github.event_name == 'push' && (startsWith(github.ref, 'refs/tags') || github.ref_name == 'dev')}}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/arm64/v8, linux/amd64

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,11 @@
 ARG IMAGE=python:3.9-alpine
 FROM ${IMAGE}
 
+# Build argument populated automatically by docker during build with the target architecture we are building for (eg: 'amd64')
+# Usefuil to differentiate the build process for each architecture
+# https://docs.docker.com/engine/reference/builder/#automatic-platform-args-in-the-global-scope
+ARG TARGETARCH
+
 # Environment vars we can configure against
 # But these are optional, so we won't define them now
 #ENV HA_URL http://hass:8123
@@ -15,7 +20,8 @@ VOLUME /conf
 VOLUME /certs
 
 # Install system dependencies, saving the apk cache with docker mount: https://docs.docker.com/build/cache/#keep-layers-small
-RUN --mount=type=cache,target=/var/cache/apk/ \
+# Specify the architecture in the cache id, otherwise the apk cache of different architectures will conflict
+RUN --mount=type=cache,id=apk-${TARGETARCH},sharing=locked,target=/var/cache/apk/ \
     apk add tzdata build-base gcc libffi-dev openssl-dev musl-dev cargo rust curl
 
 # Copy AppDaemon Python package into the image
@@ -23,7 +29,8 @@ WORKDIR /usr/src/app
 COPY ./dist/*.whl .
 
 # Install the Python package, saving the pip cache with docker mount: https://docs.docker.com/build/cache/#keep-layers-small
-RUN --mount=type=cache,target=/root/.cache/pip \
+# Specify the architecture in the cache id, otherwise the pip cache of different architectures will conflict
+RUN --mount=type=cache,id=pip-${TARGETARCH},sharing=locked,target=/root/.cache/pip \
     pip install *.whl &&\
     rm *.whl
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,4 @@
 ARG IMAGE=alpine:3.17
-FROM ${IMAGE} as builder
-
-WORKDIR /build
-
-# Install dependencies
-RUN apk add --no-cache git python3 python3-dev py3-pip py3-wheel build-base gcc libffi-dev openssl-dev musl-dev cargo
-
-# Fetch requirements
-COPY requirements.txt .
-RUN pip install -r requirements.txt
-
 FROM ${IMAGE}
 
 # Build argument populated automatically by docker during build with the target architecture we are building for (eg: 'amd64')

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,15 +24,14 @@ VOLUME /certs
 RUN --mount=type=cache,id=apk-${TARGETARCH},sharing=locked,target=/var/cache/apk/ \
     apk add tzdata build-base gcc libffi-dev openssl-dev musl-dev cargo rust curl
 
-# Copy AppDaemon Python package into the image
 WORKDIR /usr/src/app
-COPY ./dist/*.whl .
 
 # Install the Python package, saving the pip cache with docker mount: https://docs.docker.com/build/cache/#keep-layers-small
 # Specify the architecture in the cache id, otherwise the pip cache of different architectures will conflict
 RUN --mount=type=cache,id=pip-${TARGETARCH},sharing=locked,target=/root/.cache/pip \
-    pip install *.whl &&\
-    rm *.whl
+    # Mount the project directory containing the built Python package in the image, so it is available for pip install
+    --mount=type=bind,source=./dist/,target=/usr/src/app/ \
+    pip install *.whl
 
 # Copy sample configuration directory and entrypoint script
 COPY ./conf ./conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,7 @@ WORKDIR /usr/src/app
 RUN --mount=type=cache,id=pip-${TARGETARCH},sharing=locked,target=/root/.cache/pip \
     # Mount the project directory containing the built Python package in the image, so it is available for pip install
     --mount=type=bind,source=./dist/,target=/usr/src/app/ \
+    # Install the package
     pip install *.whl
 
 # Copy sample configuration directory and entrypoint script

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ build-backend = "setuptools.build_meta"
 # Tell setuptools how to find the package source files
 # https://setuptools.pypa.io/en/latest/userguide/package_discovery.html
 [tool.setuptools.packages.find]
-exclude = ["contrib", "docs", "tests*"]
+exclude = ["contrib", "docs", "docs.*", "tests*"]
 
 # Dynamically read version from version.py module
 # https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html#dynamic-metadata


### PR DESCRIPTION
This PR is built on top of #1655, augmenting it with the new project setup (`pyproject.toml` instead of `requirements.txt`) and CI pipeline.

## Description 
- Always build the Docker image and Python package (pushing only with tag or `dev` branch) as part of the Github pipeline.
This way we can easily catch any problem in the build process, without having to first merge the changes inside `dev`.
- Use Python package built during the `build_package` job for building the Docker image. This way we avoid having to copy the entire project source inside the image, reducing the image size.
At the same time this process "mimics" the step an end-user of the package does (a `pip install`), so we can verify that the package can indeed install correctly.
- Optimize the docker build cache by using `RUN --mount=type=cache` to speed up the process between subsequent builds.
- Small fix to the `pyproject.toml`: exclude the static assets inside `docs.` folder, otherwise they get included as part of the Python package, unnecessarily bloating it