### PR TITLE
Fix Docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,20 +1,18 @@
 .git
 .gitignore
 .github
+.pytest_cache
 
 Dockerfile
 .dockerignore
 
-azure-pipelines.yml
 .pre-commit-config.yaml
-.semaphore
 
 *.md
 !README*.md
 MANIFEST.in
-setup.py
 *.rst
 
+# Documentation
 docs
-conf
 .readthedocs.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG IMAGE=alpine:3.17
+ARG IMAGE=python:3.9-alpine
 FROM ${IMAGE}
 
 # Build argument populated automatically by docker during build with the target architecture we are building for (eg: 'amd64')


### PR DESCRIPTION
-  Leave `conf` directory inside Docker build context, since it is used at runtime to copy the default appdaemon configuration.
- Revert to `python:3.9-alpine` base image