### PR TITLE
CI: Update dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,6 @@
 version: 2
 updates:
+# Enable version updates for pip
 - package-ecosystem: pip
   directory: "/"
   schedule:
@@ -27,3 +28,17 @@ updates:
   - dependency-name: iso8601
     versions:
     - 0.1.13
+
+# Maintain dependencies for GitHub Actions
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: "weekly"
+
+# Enable version updates for Docker
+- package-ecosystem: "docker"
+  # Look for a `Dockerfile` in the `root` directory
+  directory: "/"
+  # Check for updates once a week
+  schedule:
+    interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,28 +6,6 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 10
-  ignore:
-  - dependency-name: python-socketio
-    versions:
-    - 5.0.4
-    - 5.1.0
-  - dependency-name: python-engineio
-    versions:
-    - 4.0.0
-    - 4.0.1
-  - dependency-name: bcrypt
-    versions:
-    - 3.2.0
-  - dependency-name: aiohttp
-    versions:
-    - 3.7.4
-  - dependency-name: pygments
-    versions:
-    - 2.7.4
-    - 2.8.0
-  - dependency-name: iso8601
-    versions:
-    - 0.1.13
 
 # Maintain dependencies for GitHub Actions
 - package-ecosystem: "github-actions"


### PR DESCRIPTION
## Description
- remove `ignored` rules from pip updates, since we are using more recent versions of those dependencies, so telling the bot to ignore those old versions has no sense
- monitor Docker updates
- monitor Github Actions update