### PR TITLE
feat(ISSUE_TEMPLATE): add github issue forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,0 +1,50 @@
+name: Bug Report
+description: Report an issue with AppDaemon.
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Also tell us, what did you expect to happen?
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: What version of AppDaemon are you running?
+      placeholder: 4.0.3
+    validations:
+      required: true
+  - type: dropdown
+    id: installation
+    attributes:
+      label: Installation type
+      description: How are you running AppDaemon?
+      options:
+        - Home Assistant add-on
+        - Python virtual environment
+        - Docker container
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
+      render: sh
+
+  - type: textarea
+    attributes:
+      label: Anything else?
+      description: |
+        Links? References? Anything that will give us more context about the issue you are encountering!
+
+        Tip: You can attach images or by clicking this area to highlight it and then dragging files in.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: I have a question or need support
+    url: https://appdaemon.readthedocs.io/en/latest/index.html#assistance
+    about: We use GitHub for tracking bugs and discuss new features, check our website for resources on getting help.

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,0 +1,16 @@
+name: Feature Request
+description: Suggest a new feature.
+labels: ["enhancement"]
+body:
+  - type: checkboxes
+    attributes:
+      label: Is there an existing feature request for this?
+      description: Please search to see if there is already a Github issue for the feature you are requesting.
+      options:
+      - label: I have searched the existing issues
+        required: true
+  - type: textarea
+    id: feature
+    attributes:
+      label: Your feature request
+      description: How do you think AppDaemon could be improved/what is currently missing?


### PR DESCRIPTION
Add [Github issue forms](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms) to help new users in filling out bug reports or feature requests.
After merging, you can try it out by trying to open an issue. There should be a dialog and a form to fill out.

## Description
- Help new users in providing helpful information to better diagnose their issue (expected behaviour, what type of installation they have, the appdaemon version they are running, application logs...). This way we have more context about what is going on and can better understand the underlying issue.
- Differentiate between issue and feature request for easier management of Github issues. 
- Auto-label bug reports with "issue" and feature requests with "enhancement" labels, for easier filtering in Github. 
- Add link to support page of official AppDaemon documentation, for easier discoverability of official forum and Discord chat.