### PR TITLE
ci(stale-issues.yml): add `stale` action to Github CI

### DIFF
--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -1,0 +1,47 @@
+# First mark the issue as `stale` according to `days-before-stale`, then close it if no activity for `days-before-close`
+name: 'Close stale issues and PRs'
+on:
+  schedule:
+    # run at 00:30 on Sunday UTC
+    - cron: '30 0 * * 0'
+  # To manually trigger from Github UI and debug this workflow
+  workflow_dispatch:
+
+permissions:
+  # To label and close issues
+  issues: write
+  # To label and close PR
+  pull-requests: write
+
+# For debug purposes
+env:
+  DRY_RUN: "true"
+
+jobs:
+  # Consider ONLY issue with label `question` OR `wait-response`
+  stale_labeled:
+    name: question, wait-response
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v7
+        with:
+          stale-issue-message: 'This issue is stale because it has been open 45 days with no activity. Remove stale label or comment or this will be closed in 15 days.'
+          close-issue-message: 'Please re-open this issue whenever you have new information available'
+          days-before-stale: 45
+          days-before-close: 15
+          any-of-labels: "question,wait-response"
+          debug-only: "${{ env.DRY_RUN }}"
+
+  # Consider ONLY issues that DO NOT have any of the labels defined below
+  stale_unlabeled:
+    name: without label
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v7
+        with:
+          stale-issue-message: 'This issue is stale because it has been open 6 months with no activity. Remove stale label or comment or this will be closed in 15 days.'
+          close-issue-message: 'Please re-open this issue whenever you have new information available'
+          days-before-stale: 180
+          days-before-close: 15
+          exempt-issue-labels: "bug,enhancement,question,wait-response,Work In Progress"
+          debug-only: "${{ env.DRY_RUN }}"


### PR DESCRIPTION
Fixes #1681.

The action run automatically at 00:30 on Sunday UTC.
To test this out, the Github action can be run manually after being merged into `dev` from the Github UI:
`Actions` ->`Close stale issues and PRs` -> `Run Workflow` button

N.B.: For now the `DRY_RUN` option is true, that means no issue will be touched. It is useful to check if the configuration is correct with a manual run.