### PR TITLE
build(dockerStart.sh): refactor `apk add` command

### DIFF
--- a/conf/.gitignore
+++ b/conf/.gitignore
@@ -1,3 +1,3 @@
 test
-# config file used during development
-appdaemon.yaml
+# avoid commitinng configuration files used during development of Docker build
+*.yaml


### PR DESCRIPTION
## Description
- Guard against the corner case of `system_packages.txt` files not having a whitespace inside, causing the package names to be merged together.
- Remove `--no-cache` option from apk, speeding up subsequent startup times of the same appdaemon container. 
- Avoid running `apk add` if no `system_packages.txt` is defined, improving startup times of container.