### PR TITLE
ci(build-deploy.yml): correctly set Docker latest tag only on release versions

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -134,6 +134,21 @@ jobs:
         uses: docker/metadata-action@v4.3.0
         with:
           images: ${{ env.IMAGE_NAME }}
+          # Customize the generation of Docker `latest` tag
+          # Tag with `latest` the git tags that do not have a "pre-release" component in the end (e.g. `3.0.0`)
+          # Avoid tagging with `latest` the git tag that have a "pre-release" component in the end (e.g. `3.0.0b1`)
+          # If no git tag, fallback to branch or PR name
+          tags: |
+            # If the git tag follows PEP440 conventions, use it as the resulting docker tag (both releases and pre-releases)
+            type=pep440,pattern={{version}}
+
+            # If the git tag does NOT have a pre-release ending (e.g. `3.0.0`), it is a release version to be tagged as `latest`
+            type=match,value=latest,pattern=pattern=^\d\.\d+\.\d+$
+
+            # If no git tag is used, fallback to tagging with branch or PR name
+            type=ref,event=branch
+            type=ref,event=pr
+
       # Build and push Docker image with Buildx (push image only with a tag or push on `dev` branch)
       # https://github.com/docker/build-push-action
       - name: Build and push Docker image


### PR DESCRIPTION
The default configuration for the `docker/metadata-action@v4.3.0` is to tag with `latest` whenever there is a git tag, but this is not compatible with our use of `pre-release` tags (alpha, beta, etc..).
This versions should still be tagged, just not with `latest`.

## Description
- Tag with `latest` the git tags that do not have a "pre-release" component in the end (e.g. `3.0.0`)
- Avoid tagging with `latest` the git tag that have a "pre-release" component in the end (e.g. `3.0.0b1`)
- If no git tag, fallback to using branch or PR name as tag