### PR TITLE
Docs: update installation and configuration instructions

### DIFF
--- a/docs/CONFIGURE.rst
+++ b/docs/CONFIGURE.rst
@@ -693,7 +693,7 @@ With this app in place we will be able to test the App part of AppDaemon
 when we first run it.
 
 Configuring the HTTP Component
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+------------------------------
 
 The HTTP component provides a unified front end to `AppDaemon's Admin Interface`, `HADashboard`, and the `AppDaemon API`. It requires some initial configuration, but the dashboard and admin interface can be separately enabled or disabled. This component also creates a folder in the configuration directory called ``www``, if it doesn't exist. To serve custom static content like images, videos or html pages, simply drop the content into the www folder and it becomes available via the browser or dashboard. Content stored in this folder can be accessed using ``http://AD_IP:Port/local/<content to be accessed>``. Where `AD_IP:Port` is the url as defined below using the http component.
 
@@ -771,14 +771,14 @@ The above configuration assumes that the user has a folder, that has stored with
 the videos stored in the video_clip folder via a browser or Dashboard, the url can be used ``http://AD_IP:Port/local/videos/<video to be accessed>``. Like wise, the pictures can be accessed using ``http://AD_IP:Port/local/pictures/<picture to be accessed>``. Using this directive does support the use of relative paths.
 
 Configuring the Dashboard
-~~~~~~~~~~~~~~~~~~~~~~~~~
+-------------------------
 
 Configuration of the dashboard component (HADashboard) is described
 separately in the `Dashboard <DASHBOARD_INSTALL.html>`__ documentation.
 Note that the dashboard depends on the HTTP section being configured to correctly function.
 
 Configuring the API
-~~~~~~~~~~~~~~~~~~~
+-------------------
 
 The AppDaemon App API is configured by adding a top-level directive to appdaemon.yaml:
 
@@ -789,7 +789,7 @@ The AppDaemon App API is configured by adding a top-level directive to appdaemon
 It takes no arguments.
 
 Configuring the Admin Interface
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-------------------------------
 
 The updated admin Interface, new in 4.2.0 is a front end to AppDaemon that allows you to monitor it's inner workings such as
 thread activity, registered callbacks and entities. Over time it is expected to evolve into a full management tool
@@ -810,7 +810,7 @@ Note: the old admin interface can still be used by specifying the ``old_admin`` 
     old_admin:
 
 Accessing Directories via Apps
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+------------------------------
 
 Directories used by AD internally either declared by the user or not, can be accessed by the user via apps. The following directories
 are available:

--- a/docs/DOCKER_TUTORIAL.rst
+++ b/docs/DOCKER_TUTORIAL.rst
@@ -166,6 +166,7 @@ If you'd like to ``tail`` the latest output, try this:
     $ docker logs -f --tail 20 appdaemon
 
 .. _Docker-Upgrading:
+
 Upgrading
 ---------
 

--- a/docs/DOCKER_TUTORIAL.rst
+++ b/docs/DOCKER_TUTORIAL.rst
@@ -165,6 +165,7 @@ If you'd like to ``tail`` the latest output, try this:
 
     $ docker logs -f --tail 20 appdaemon
 
+.. _Docker-Upgrading:
 Upgrading
 ---------
 

--- a/docs/DOCKER_TUTORIAL.rst
+++ b/docs/DOCKER_TUTORIAL.rst
@@ -1,9 +1,11 @@
-AppDaemon with Docker
-=====================
+.. _Docker tutorial:
 
-A quick tutorial to AppDaemon with Docker
+Docker tutorial
+===============
 
-About Docker
+A quick tutorial to using AppDaemon with Docker
+
+Introduction
 ------------
 
 `Docker <https://www.docker.com>`_ is a popular application container technology. Application
@@ -19,15 +21,8 @@ multiple ways of doing some of these steps which are removed for the
 sake of keeping it simple. As your needs change, just remember there's
 probably a way to do what you want!
 
-Available Images
-----------------
-
-Starting with AppDaemon 4.1.0, we suport multi-arch images on Docker Hub.
-
-Currently supported architectures: linux/arm64/v8,linux/amd64,linux/arm/v6,linux/arm/v7
-
-Prereqs
--------
+Requirements
+------------
 
 This guide assumes:
 
@@ -35,8 +30,8 @@ This guide assumes:
 * You have Home Assistant up and running
 * You are comfortable with some tinkering. This is a pre-req for AppDaemon too!
 
-Testing your System
--------------------
+First steps
+-----------
 
 Our first step will be to verify that we can get AppDaemon running on
 our machine, which tests that we can successfully *pull* (download)
@@ -53,9 +48,9 @@ Now, on your Docker host, for Linux users, run the following command,
 substituting the values above in the quotes below. (Note: to create a long-lived token, click your user icon in the HA front end and look for the Long-Lived Access Tokens card. If you do not
 need a TOKEN, you can omit the entire -e TOKEN line)
 
-::
+.. code:: console
 
-    docker run --rm -it -p 5050:5050 \
+    $ docker run --rm -it -p 5050:5050 \
       -e HA_URL="<your HA_URL value>" \
       -e TOKEN="<your TOKEN value>" \
       -e DASH_URL="http://$HOSTNAME:5050" \
@@ -74,21 +69,21 @@ look for lines like these being outputs:
 
 HASS: Connected to Home Assistant 0.80.0
 
-::
+.. code:: console
 
     2017-04-01 14:26:48.361140 INFO Connected to Home Assistant 0.80.0
 
 The `apps` capability of AppDaemon is working, running the example Hello
 World app
 
-::
+.. code:: console
 
     2017-04-01 14:26:48.330084 INFO hello_world: Hello from AppDaemon
     2017-04-01 14:26:48.333040 INFO hello_world: You are now ready to run Apps!
 
 The `dashboard` capability of AppDaemon has started.
 
-::
+.. code:: console
 
     2018-10-25 16:53:09.105214 INFO Starting Dashboards
 
@@ -116,9 +111,9 @@ store it in the same location as Home Assistant. I like to keep a folder
 structure under ``/docker`` on my systems, so we can do something
 like:
 
-::
+.. code:: console
 
-    mkdir -p /docker/appdaemon/conf
+    $ mkdir -p /docker/appdaemon/conf
 
 Next, we will run a container again, omitting the ``--rm -it`` parameters
 and adding ``-d`` so that it stays background and doesn't disappear when
@@ -127,9 +122,9 @@ will auto-start on system boot and restart on failures, and lastly
 specify our ``conf`` folder location. Note that the folder path must be
 fully qualified and not relative.
 
-::
+.. code:: console
 
-    docker run --name=appdaemon -d -p 5050:5050 \
+    $ docker run --name=appdaemon -d -p 5050:5050 \
       --restart=always \
       -e HA_URL="<your HA_URL value>" \
       -e TOKEN="<your TOKEN value>" \
@@ -155,23 +150,23 @@ folder and AppDaemon will load them see the `AppDaemon Installation
 page <INSTALL.html>`__ for full instructions on AppDaemon configuration.
 Have fun!
 
-Viewing AppDaemon Log Output
-----------------------------
+Logs
+----
 
-You can view the output of your AppDaemon with this command:
+You can view the AppDaemon loda with this command:
 
-::
+.. code:: console
 
-    docker logs appdaemon
+    $ docker logs appdaemon
 
-If you'd like to tail the latest output, try this:
+If you'd like to ``tail`` the latest output, try this:
 
-::
+.. code:: console
 
-    docker logs -f --tail 20 appdaemon
+    $ docker logs -f --tail 20 appdaemon
 
-Upgrading AppDaemon
--------------------
+Upgrading
+---------
 
 Upgrading with Docker really doesn't exist in the same way as with
 non-containerized apps. Containers are considered ephemeral and are an
@@ -186,12 +181,12 @@ this guide we are keeping it simple!)
 
 Run the following commands:
 
-::
+.. code:: console
 
-    docker stop appdaemon
-    docker rm appdaemon
-    docker pull acockburn/appdaemon:latest
-    docker run --name=appdaemon -d -p 5050:5050 \
+    $ docker stop appdaemon
+    $ docker rm appdaemon
+    $ docker pull acockburn/appdaemon:latest
+    $ docker run --name=appdaemon -d -p 5050:5050 \
       --restart=always \
       -e HA_URL="<your HA_URL value>" \
       -e TOKEN="<your TOKEN value>" \
@@ -199,69 +194,71 @@ Run the following commands:
       -v <your_conf_folder>:/conf \
       acockburn/appdaemon:latest
 
-Controlling the AppDaemon Container
------------------------------------
-
-To restart AppDaemon:
-
-::
-
-    docker restart appdaemon
-
-To stop AppDaemon:
-
-::
-
-    docker stop appdaemon
-
-To start AppDaemon back up after stopping:
-
-::
-
-    docker start appdaemon
-
-To check the running state, run the following and look at the 'STATUS'
+Managing the container
+----------------------
+Check status
+^^^^^^^^^^^^
+To check the running state, run the following and look at the ``STATUS``
 column:
 
-::
+.. code:: console
 
-    docker ps -a
+    $ docker ps -a
 
-Running with AppDaemon Debug
-----------------------------
+Start
+^^^^^
+.. code:: console
 
-If you need to run AppDaemon with Debug, it may be easiest to stop your
-normal AppDaemon and run a temporary container with the debug flag set.
-This presumes you already have a configured ``conf`` folder you are
-debugging, so we don't need to pass the HA/DASH variables into the
+    $ docker start appdaemon
+
+Stop
+^^^^
+.. code:: console
+
+    $ docker stop appdaemon
+
+Restart
+^^^^^^^
+.. code:: console
+
+    $ docker restart appdaemon
+
+
+Troubleshooting
+---------------
+If you need to run AppDaemon with the ``debug`` flag, it may be easier to stop your
+normal AppDaemon and run a temporary container with the ``debug`` flag set.
+This assumes you already have a configured ``conf`` folder you are
+debugging, so you don't need to pass the HA/DASH variables into the
 container.
 
 Run the following commands:
 
-::
+.. code:: console
 
-    docker stop appdaemon
-    docker run --rm -it -p 5050:5050 \
+    $ docker stop appdaemon
+    $ docker run --rm -it -p 5050:5050 \
       -v <your_conf_folder>:/conf \
       acockburn/appdaemon:latest -D DEBUG
 
-Once you are done with the debugging, start the non-debug container back up:
+Once you are done with the debugging, ``CTRL-C`` to stop the container and
+restart the normal container:
 
-::
+.. code:: console
 
-    docker start appdaemon
+    $ docker start appdaemon
 
 You can also append any other AppDaemon flags to the end of the command line if desired, e.g. to use time travel.
 
 Timezones
----------
+^^^^^^^^^
 
 Some users have reported issues with the Docker container running in different timezones to the host OS - this is obviously problematic for any of the scheduler functions.
 Adding the following to the Docker command line has helped some users:
 
-::
+.. code:: console
 
-     -v /etc/localtime:/etc/localtime:ro
+    -v /etc/localtime:/etc/localtime:ro
 
 Home Assistant SSL
 ------------------
@@ -271,23 +268,49 @@ will want to point to the location of the certificate files as part of
 the container creation process. Add ``-v <your_cert_path>:/certs`` to
 the ``docker run`` command line
 
-Removing AppDaemon
-------------------
+Uninstalling
+------------
 
-If you no longer want to use AppDaemon ``confused``, use the following commands:
+If you no longer want to use AppDaemon, use the following commands:
 
-::
+.. code:: console
 
-    docker kill appdaemon
-    docker rm appdaemon
-    docker rmi acockburn/appdaemon:latest
+    $ docker kill appdaemon
+    $ docker rm appdaemon
+    $ docker rmi acockburn/appdaemon:latest
 
 You can delete the ``conf`` folder if you wish at this time too.
 AppDaemon is now completely removed.
 
-Adding Dependencies
--------------------
+Runtime dependencies
+--------------------
 
-Sometimes it can be helpful to install additional Python dependencies into the Docker container before AppDaemon starts, to allow additional libraries to be used from Apps. The Docker script will recursively search the CONF directory for any files named ``requirements.txt``. All the found requirements will be used as input to pip3 to install any packages that they describe.
+Python packages
+^^^^^^^^^^^^^^^
+If your AppDaemon apps require additional Python dependencies, it is possible to install them on container startup.
+The Docker *entrypoint* script recursively searches inside the CONF directory for any files named ``requirements.txt``.
 
-It's also often helpful to add system packages to the Docker container before AppDaemon starts, to allow any custom python packages that depend on other `system packages <https://pkgs.alpinelinux.org/packages>`_ to install without issue. The Docker script will recursively search the CONF directory for any files named ``system_packages.txt``. Packages should be listed either space delimited or newline delimited. These packages will be used as input to ``apk add`` to install any packages that they describe.
+See the following example displaying the content of a sample ``requirements.txt``:
+
+.. code-block:: text
+
+    # requirements.txt
+    requests==2.28.2
+
+All the ``requirements.txt`` found will be used as input to ``pip install -r requirements.txt``, installing all the Python package requested.
+
+OS dependencies
+^^^^^^^^^^^^^^^
+You can add system packages provided by the `Alpine repository <https://pkgs.alpinelinux.org/packages>`_.
+This might be useful if your additional Python packages depend on them (for instance they may need ``gcc`` or the Python library headers for compiling ``wheels``).
+The packages are installed using ``apk``.
+
+The Docker *entrypoint* script recursively searches inside the CONF directory for any files named ``system_packages.txt``.
+The file should contain the name of all the packages, either space delimited or newline delimited.
+These packages will be used as input to ``apk add``.
+
+See the following example displaying the content of a sample ``system_packages.txt``:
+
+.. code-block:: text
+
+    build-base gcc curl

--- a/docs/INSTALL.rst
+++ b/docs/INSTALL.rst
@@ -283,8 +283,7 @@ Versioning Strategy
 AppDaemon follows a simple 3 point versioning strategy in the format ``x.y.z``:
 
 x: major version number
-    Incremented when very significant changes have been made to the platform, or
-sizeable new functionality has been added.
+    Incremented when very significant changes have been made to the platform, or sizeable new functionality has been added.
 
 y: minor version number
     Incremented when incremental new features have been added, or breaking changes have occurred

--- a/docs/INSTALL.rst
+++ b/docs/INSTALL.rst
@@ -11,8 +11,6 @@ The following installation methods are supported:
 - :ref:`pip-install`
 - :ref:`Home-Assistant-add-on`
 
-Note: *Windows* and *Raspbian* users should check the environment-specific section at the end of this doc for additional information.
-
 .. _docker-install:
 
 Docker
@@ -29,7 +27,7 @@ Currently supported architectures:
 - linux/arm64/v8
 - linux/amd64
 
-To start a container named ``appdaemon``, exposing the *HADashboard* on port 5050, use the following command:
+To start a container named ``appdaemon``, exposing the *HADashboard* on port ``5050``, use the following command:
 
 .. code:: console
 
@@ -43,20 +41,8 @@ To start a container named ``appdaemon``, exposing the *HADashboard* on port 505
         -e TOKEN="my_long_liven_token" \
         acockburn/appdaemon
 
-Environment variables
-^^^^^^^^^^^^^^^^^^^^^
-
-When you start the AppDaemon image, you can adjust the some configuration variables of AppDaemon by passing one or more environment variables on the ``docker run`` command:
-
-======  ========================================================
-Name    Description
-======  ========================================================
-HA_URL  The URL of your running Home Assistant instance
-TOKEN   Long-Lived token to authenticates against Home Assistant
-======  ========================================================
-
-Accessing configuration
-^^^^^^^^^^^^^^^^^^^^^^^
+Configuration folder
+^^^^^^^^^^^^^^^^^^^^
 
 AppDaemon uses the ``/conf`` directory to store its configuration data.
 To access this folder from the host system, you need to create a data directory outside the container and `mount this to the directory used inside the container <https://docs.docker.com/engine/tutorials/dockervolumes/#mount-a-host-directory-as-a-data-volume>`_.
@@ -74,7 +60,7 @@ The following steps illustrate the procedure;
         --restart=always \
         --network=host \
         -p 5050:5050 \
-        -v <conf_folder>:/conf \
+        -v /my/own/datadir:/conf \
         -e HA_URL="http://homeassistant.local:8123" \
         -e TOKEN="my_long_liven_token" \
         acockburn/appdaemon
@@ -82,6 +68,18 @@ The following steps illustrate the procedure;
 The ``-v /my/own/datadir:/conf`` part of the command mounts the ``/my/own/datadir`` directory from the underlying host system as ``/conf`` inside the container, where AppDaemon by default will write its data files.
 
 The first you start the container, AppDaemon will write its own sample configuration files in this directory.
+
+Environment variables
+^^^^^^^^^^^^^^^^^^^^^
+
+When you start the AppDaemon image, you can adjust some of its configuration variables by passing one or more environment variables on the ``docker run`` command:
+
+======  ========================================================
+Name    Description
+======  ========================================================
+HA_URL  The URL of your running Home Assistant instance
+TOKEN   Long-Lived token to authenticates against Home Assistant
+======  ========================================================
 
 For a more in-depth guide to Docker, see the :ref:`Docker tutorial`.
 
@@ -107,16 +105,21 @@ If you do that, then Home Assistant will stop working due to conflicting depende
 
     $ pip install appdaemon
 
+Note: There are some OS-specific instructions for :ref:`Windows` and :ref:`Raspberry Pi OS` users.
 
-Raspbian
-^^^^^^^^
+.. _Raspberry Pi OS:
 
-Some users have reported the following additional requirements:
+Raspberry Pi OS
+^^^^^^^^^^^^^^^
+
+Some users have reported the need to install these additional requirements:
 
 .. code:: console
 
     $ sudo apt install python-dev
     $ sudo apt install libffi-dev
+
+.. _Windows:
 
 Windows
 ^^^^^^^
@@ -158,17 +161,18 @@ Running
 Pip
 ---
 
-You can run AppDaemon from the command line as follows:
+You can run AppDaemon from the command line as follows.
+Note: make sure first to create a directory to contain all AppDaemon configuration files!
 
 .. code:: console
 
-    $ appdaemon -c /home/homeassistant/conf
+    $ appdaemon -c <patch_to_config_folder>
 
-If all is well, you should see something like the following:
+You should see something like the following:
 
 .. code:: console
 
-    $ appdaemon -c /home/homeassistant/conf
+    $ appdaemon -c <patch_to_config_folder>
     2016-08-22 10:08:16,575 INFO Got initial state
     2016-08-22 10:08:16,576 INFO Loading Module: /home/homeassistant/conf/apps/hello.py
     2016-08-22 10:08:16,578 INFO Loading Object hello_world using class HelloWorld from module hello
@@ -177,76 +181,65 @@ If all is well, you should see something like the following:
 
 CLI arguments
 -------------
+The following CLI arguments are available:
 
 .. code:: console
 
-    usage: appdaemon [-h] [-c CONFIG] [-p PIDFILE] [-t TIMEWARP] [-s STARTTIME]
-                       [-e ENDTIME] [-C CONFIGFILE]
-                       [-D {DEBUG,INFO,WARNING,ERROR,CRITICAL}]
-                       [-m MODULEDEBUG MODULEDEBUG] [-v]
+    $ usage: appdaemon [-h] [-c CONFIG] [-p PIDFILE] [-t TIMEWARP] [-s STARTTIME] [-e ENDTIME] [-C CONFIGFILE] [-D {DEBUG,INFO,WARNING,ERROR,CRITICAL}] [-m MODULEDEBUG MODULEDEBUG] [-v]
 
     options:
-      -h, --help            show this help message and exit
-      -c CONFIG, --config CONFIG
+    -h, --help            show this help message and exit
+    -c CONFIG, --config CONFIG
                             full path to config directory
-      -p PIDFILE, --pidfile PIDFILE
+    -p PIDFILE, --pidfile PIDFILE
                             full path to PID File
-      -t TIMEWARP, --timewarp TIMEWARP
+    -t TIMEWARP, --timewarp TIMEWARP
                             speed that the scheduler will work at for time travel
-      -s STARTTIME, --starttime STARTTIME
-                            start time for scheduler <YYYY-MM-DD HH:MM:SS|YYYY-MM-
-                            DD#HH:MM:SS>
-      -e ENDTIME, --endtime ENDTIME
-                            end time for scheduler <YYYY-MM-DD HH:MM:SS|YYYY-MM-
-                            DD#HH:MM:SS>
-      -C CONFIGFILE, --configfile CONFIGFILE
+    -s STARTTIME, --starttime STARTTIME
+                            start time for scheduler <YYYY-MM-DD HH:MM:SS|YYYY-MM-DD#HH:MM:SS>
+    -e ENDTIME, --endtime ENDTIME
+                            end time for scheduler <YYYY-MM-DD HH:MM:SS|YYYY-MM-DD#HH:MM:SS>
+    -C CONFIGFILE, --configfile CONFIGFILE
                             name for config file
-      -D {DEBUG,INFO,WARNING,ERROR,CRITICAL}, --debug {DEBUG,INFO,WARNING,ERROR,CRITICAL}
+    -D {DEBUG,INFO,WARNING,ERROR,CRITICAL}, --debug {DEBUG,INFO,WARNING,ERROR,CRITICAL}
                             global debug level
-      -m MODULEDEBUG MODULEDEBUG, --moduledebug MODULEDEBUG MODULEDEBUG
-      -v, --version         show program's version number and exit
+    -m MODULEDEBUG MODULEDEBUG, --moduledebug MODULEDEBUG MODULEDEBUG
+    -v, --version         show program's version number and exit
 
--c is the path to the configuration directory. If not specified,
-AppDaemon will look for a file named ``appdaemon.yaml`` first in
-``~/.homeassistant`` then in ``/etc/appdaemon``. If the directory is not
-specified and it is not found in either location, AppDaemon will raise
-an exception. In addition, AppDaemon expects to find a dir named
-``apps`` immediately subordinate to the config directory.
+A brief description of them follows:
 
--C allows the user to override the name of the appdaemon config file and set it to soemthing other than
-``appdaemon.yaml``
+``-c`` path to the configuration directory
+    If not specified, AppDaemon will look for a file named ``appdaemon.yaml`` under the following default locations:
 
--d and -p are used by the init file to start the process as a daemon and
-are not required if running from the command line.
+    - ``~/.homeassistant/``
+    - ``/etc/appdaemon``
 
--D can be used to increase the debug level for internal AppDaemon
-operations as well as apps using the logging function.
+    If no file is found in either location, AppDaemon will raise an exception. In addition, AppDaemon expects to find a dir named ``apps`` immediately subordinate to the config directory.
 
-The -s, -i, -t and -e options are for the Time Travel feature and should
-only be used for testing. They are described in more detail in the API
-documentation.
+``-C`` name of the configuration file (default: ``appdaemon.yaml``)
 
-Starting At Reboot
-------------------
+.. TODO: document -d in appdaemon help text
 
-To run ``AppDaemon`` at reboot, you can set it up to run as a ``systemd
-service`` as follows.
+``-d``, ``-p`` used by the init file to start the process as a daemon
+    Not required if running from the command line.
 
-Add Systemd Service (appdaemon@appdaemon.service)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``-D`` increase the debug level for internal AppDaemon operations, and configure debug logs for the apps.
 
-First, create a new file using vi:
+``-s``, ``-i``, ``-t``, ``-e`` time travel options
+    Useful only for testing. Described in more detail in the API documentation.
 
-.. code:: bash
+Automatically starting on boot
+------------------------------
 
-    $ sudo vi /etc/systemd/system/appdaemon@appdaemon.service
+To run ``AppDaemon`` every time you restart your machine, you can set it up to run as a ``systemd service`` as follows.
 
-Add the following, making sure to use the correct full path for your
-config directory. Also, make sure you edit the ``User`` to a valid user
-to run AppDaemon, usually the same user as you are running Home
-Assistant with is a good choice.
+Systemd service file
+^^^^^^^^^^^^^^^^^^^^
 
-::
+Create a Systemd service file ``/etc/systemd/system/appdaemon@appdaemon.service`` and add the following content.
+Make sure to use the correct full path for your configuration directory and that you edit the ``User`` field to a valid user that can run AppDaemon, usually the same user that is running the Home Assistant process is a good choice.
+
+.. code:: console
 
     [Unit]
     Description=AppDaemon
@@ -258,14 +251,14 @@ Assistant with is a good choice.
     [Install]
     WantedBy=multi-user.target
 
-The above should work for hasbian, but if your ``homeassistant`` service is
+The above should work for Raspberry Pi OS, but if your ``homeassistant`` service is
 named something different you may need to change the ``After=`` lines to
 reflect the actual name.
 
-Activate Systemd Service
-~~~~~~~~~~~~~~~~~~~~~~~~
+Activate the service
+~~~~~~~~~~~~~~~~~~~~
 
-.. code:: bash
+.. code:: console
 
     $ sudo systemctl daemon-reload
     $ sudo systemctl enable appdaemon@appdaemon.service --now
@@ -276,13 +269,13 @@ Upgrading
 =========
 
 To update AppDaemon after a new release has been published, run the
-following command to update your copy:
+following command to update your local installation:
 
 .. code:: console
 
     $ pip install --upgrade appdaemon
 
-If you are using Docker, refer to the steps in the tutorial.
+If you are using Docker, refer to the steps in the `tutorial <Docker-Upgrading>`_.
 
 Versioning Strategy
 -------------------

--- a/docs/INSTALL.rst
+++ b/docs/INSTALL.rst
@@ -1,67 +1,172 @@
+***************
+Getting started
+***************
+
 Installation
-============
+===============
 
-AppDaemon runs on Python versions 3.8, 3.9, 3.10 and 3.11. Installation is either by pip3 or Docker. There is also an official
-hass.io build.
+The following installation methods are supported:
 
-Note: Windows and Raspbian users should check the environment-specific section at the end of this doc for additional information.
+- :ref:`docker-install`
+- :ref:`pip-install`
+- :ref:`Home-Assistant-add-on`
 
-Install and Run using Docker
-----------------------------
+Note: *Windows* and *Raspbian* users should check the environment-specific section at the end of this doc for additional information.
 
-Follow the instructions in the `Docker Tutorial <DOCKER_TUTORIAL.html>`__
-
-Install Using pip3
-------------------
-
-Before running ``AppDaemon`` you will need to install the package:
-
-.. code:: bash
-
-    $ sudo pip3 install appdaemon
-
-
-**Do not** install this in the same Python virtual environment as Home Assistant. If you do that, then Home Assistant will stop working.
-
-Install Using hass.io
----------------------
-
-The official hass.io addon for AppDaemon is maintained by:
-
-- `frenck <https://github.com/hassio-addons/repository>`__.
-
-Running
--------
+.. _docker-install:
 
 Docker
-~~~~~~
+------
 
-Assuming you have set the config up as described in `the tutorial <DOCKER_TUTORIAL.html>`_ for
-Docker, you should see the logs output as follows:
+Supported architectures
+^^^^^^^^^^^^^^^^^^^^^^^
+Starting with AppDaemon 4.1.0, multi-arch images are published on the official `Docker Hub <https://hub.docker.com/r/acockburn/appdaemon>`_ repository.
 
-.. code:: bash
+Currently supported architectures:
 
-    $ docker logs appdaemon
-    2016-08-22 10:08:16,575 INFO Got initial state
-    2016-08-22 10:08:16,576 INFO Loading Module: /export/hass/appdaemon_test/conf/apps/hello.py
-    2016-08-22 10:08:16,578 INFO Loading Object hello_world using class HelloWorld from module hello
-    2016-08-22 10:08:16,580 INFO Hello from AppDaemon
-    2016-08-22 10:08:16,584 INFO You are now ready to run Apps!
+- linux/arm/v6
+- linux/arm/v7
+- linux/arm64/v8
+- linux/amd64
 
-Note that for Docker, the error and regular logs are combined.
+To start a container named ``appdaemon``, exposing the *HADashboard* on port 5050, use the following command:
 
-PIP3
-~~~~
+.. code:: console
+
+    $ docker run --name appdaemon \
+        --detach \
+        --restart=always \
+        --network=host \
+        -p 5050:5050 \
+        -v <conf_folder>:/conf \
+        -e HA_URL="http://homeassistant.local:8123" \
+        -e TOKEN="my_long_liven_token" \
+        acockburn/appdaemon
+
+Environment variables
+^^^^^^^^^^^^^^^^^^^^^
+
+When you start the AppDaemon image, you can adjust the some configuration variables of AppDaemon by passing one or more environment variables on the ``docker run`` command:
+
+======  ========================================================
+Name    Description
+======  ========================================================
+HA_URL  The URL of your running Home Assistant instance
+TOKEN   Long-Lived token to authenticates against Home Assistant
+======  ========================================================
+
+Accessing configuration
+^^^^^^^^^^^^^^^^^^^^^^^
+
+AppDaemon uses the ``/conf`` directory to store its configuration data.
+To access this folder from the host system, you need to create a data directory outside the container and `mount this to the directory used inside the container <https://docs.docker.com/engine/tutorials/dockervolumes/#mount-a-host-directory-as-a-data-volume>`_.
+This places the configuration files in a known location on the host system, and makes it easy for tools and applications on the host system to access the files.
+
+The following steps illustrate the procedure;
+
+1. Create a configuration directory on a suitable volume on your host system, e.g. ``/my/own/datadir``.
+2. Start you ``AppDaemon`` container like this:
+
+.. code:: console
+
+    $ docker run --name appdaemon \
+        --detach \
+        --restart=always \
+        --network=host \
+        -p 5050:5050 \
+        -v <conf_folder>:/conf \
+        -e HA_URL="http://homeassistant.local:8123" \
+        -e TOKEN="my_long_liven_token" \
+        acockburn/appdaemon
+
+The ``-v /my/own/datadir:/conf`` part of the command mounts the ``/my/own/datadir`` directory from the underlying host system as ``/conf`` inside the container, where AppDaemon by default will write its data files.
+
+The first you start the container, AppDaemon will write its own sample configuration files in this directory.
+
+For a more in-depth guide to Docker, see the :ref:`Docker tutorial`.
+
+.. _pip-install:
+
+Pip
+---
+
+Linux
+^^^^^
+
+**Requirements**: Python version `3.8`, `3.9`, `3.10` or `3.11`.
+
+**NOTE:** Do not install this in the same Python virtual environment as Home Assistant.
+If you do that, then Home Assistant will stop working due to conflicting dependencies.
+
+
+- Create a dedicated `Python virtual environment <https://docs.python.org/3/tutorial/venv.html>`_ for AppDaemon and activate it
+
+- To install the latest version of AppDaemon:
+
+.. code:: console
+
+    $ pip install appdaemon
+
+
+Raspbian
+^^^^^^^^
+
+Some users have reported the following additional requirements:
+
+.. code:: console
+
+    $ sudo apt install python-dev
+    $ sudo apt install libffi-dev
+
+Windows
+^^^^^^^
+
+AppDaemon under Windows has been tested with the official 3.8.1
+release of Python.
+There are a couple of caveats:
+
+-  The ``-d`` or ``--daemonize`` option is not supported owing to
+   limitations in the Windows implementation of Python.
+-  Some internal diagnostics are disabled. This is not user-visible but
+   may hamper troubleshooting of internal issues, if any crop up
+
+AppDaemon can be installed exactly as per the instructions using pip.
+
+WSL (Windows subsystem for Linux)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Windows 10+ now supports a full Linux Bash environment that is capable of
+running Python. It allows to run a multitude of Linux distributions, virtualizing a full Linux OS.
+
+It is possible to run AppDaemon in the same way
+as in a standard Linux distributions, and none of the above Windows caveats apply
+to this version.
+This is the recommended way to run AppDaemon in a Windows 10 and later environment.
+
+
+.. _Home-Assistant-add-on:
+
+Home Assistant add-on
+---------------------
+
+The official AppDaemon add-on is available in the `Home Assistant Community Add-ons Repository <https://github.com/hassio-addons/repository>`_, maintained by `frenck <https://github.com/frenck>`_.
+Please see their official documentation for installation and configuration instructions.
+
+Running
+=======
+
+Pip
+---
 
 You can run AppDaemon from the command line as follows:
 
-.. code:: bash
+.. code:: console
 
     $ appdaemon -c /home/homeassistant/conf
 
 If all is well, you should see something like the following:
 
-::
+.. code:: console
 
     $ appdaemon -c /home/homeassistant/conf
     2016-08-22 10:08:16,575 INFO Got initial state
@@ -70,10 +175,10 @@ If all is well, you should see something like the following:
     2016-08-22 10:08:16,580 INFO Hello from AppDaemon
     2016-08-22 10:08:16,584 INFO You are now ready to run Apps!
 
-AppDaemon arguments
--------------------
+CLI arguments
+-------------
 
-::
+.. code:: console
 
     usage: appdaemon [-h] [-c CONFIG] [-p PIDFILE] [-t TIMEWARP] [-s STARTTIME]
                        [-e ENDTIME] [-C CONFIGFILE]
@@ -167,68 +272,32 @@ Activate Systemd Service
 
 Now AppDaemon should be up and running and good to go.
 
-Updating AppDaemon
-------------------
+Upgrading
+=========
 
-To update AppDaemon after new code has been released, just run the
+To update AppDaemon after a new release has been published, run the
 following command to update your copy:
 
-.. code:: bash
+.. code:: console
 
-    $ sudo pip3 install --upgrade appdaemon
+    $ pip install --upgrade appdaemon
 
-If you are using docker, refer to the steps in the tutorial.
+If you are using Docker, refer to the steps in the tutorial.
 
-AppDaemon Versioning Strategy
------------------------------
+Versioning Strategy
+-------------------
 
-AppDaemon uses a simple 3 point versioning strategy of the form x.y.z
+AppDaemon follows a simple 3 point versioning strategy in the format ``x.y.z``:
 
-- x = Major Version Number
-- y = Minor Version Number
-- z = Point Version Number
-
-Major versions will be released when very significant changes have been made to the platform, or
+x: major version number
+    Incremented when very significant changes have been made to the platform, or
 sizeable new functionality has been added.
 
-Minor versions will be released when incremental new features have been added, or breaking changes have occured
+y: minor version number
+    Incremented when incremental new features have been added, or breaking changes have occurred
 
-Point releases will typically contain bugfixes, and package upgrades
+z: point version number
+    Point releases will typically contain bugfixes, and package upgrades
 
 Users should be able to expect point release upgrades to be seamless, but should check release notes for breaking changes and
 new functionality for minor or major releases.
-
-Windows Support
----------------
-
-AppDaemon runs under windows and has been tested with the official 3.8.1
-release of python. However, there are a couple of caveats:
-
--  The ``-d`` or ``--daemonize`` option is not supported owing to
-   limitations in the Windows implementation of Python.
--  Some internal diagnostics are disabled. This is not user-visible but
-   may hamper troubleshooting of internal issues if any crop up
-
-AppDaemon can be installed exactly as per the instructions for every
-other version using pip3.
-
-Windows Under the Linux Subsystem
----------------------------------
-
-Windows 10+ now supports a full Linux bash environment that is capable of
-running Python. This is essentially an Ubuntu distribution and works
-extremely well. It is possible to run AppDaemon in the same way
-as for Linux distributions, and none of the above Windows Caveats apply
-to this version. This is the recommended way to run AppDaemon in a
-Windows 10 and later environment.
-
-Raspbian
---------
-
-Some users have reported a requirement to install a couple of packages
-prior to installing AppDaemon with the pip3 method:
-
-.. code:: bash
-
-    $ sudo apt-get install python-dev
-    $ sudo apt-get install libffi-dev

--- a/docs/INSTALL.rst
+++ b/docs/INSTALL.rst
@@ -294,3 +294,8 @@ z: point version number
 
 Users should be able to expect point release upgrades to be seamless, but should check release notes for breaking changes and
 new functionality for minor or major releases.
+
+Next steps
+==========
+
+Now that you have a working setup for AppDaemon, learn how to configure it in the next section: :doc:`CONFIGURE`.

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -1,0 +1,4 @@
+<!-- Inspired by https://github.com/ferdnyc/openshot-qt/blob/56db1012f9f944d278bb2887ba6f7e8614167914/doc/_templates/layout.html -->
+<!-- Import the custom css to visualize prettier table on small screens -->
+{% extends "!layout.html" %}
+{% set css_files = css_files + ["_static/tablefix.css"] %}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -142,7 +142,7 @@ html_theme = "sphinx_rtd_theme"
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-# html_static_path = ["_static"]
+html_static_path = ["css"]
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied

--- a/docs/css/tablefix.css
+++ b/docs/css/tablefix.css
@@ -1,0 +1,11 @@
+/* override table width restrictions */
+/* Taken from https://github.com/OpenShot/openshot-qt/pull/1272 */
+.wy-table-responsive table td, .wy-table-responsive table th {
+    white-space: normal;
+}
+
+.wy-table-responsive {
+    margin-bottom: 24px;
+    max-width: 100%;
+    overflow: visible;
+}

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -25,11 +25,13 @@ AppDaemon has reached a very stable point, works reliably and is fairly feature 
 in its development. For that reason, releases have been slow in recent months. This does not mean that AppDaemon has been abandoned - it is used every day by
 the core developers, and has an active community on Discord (see below).
 
-Assistance
-==========
+Support
+=======
 
-- AppDaemon has a dedicated sub-forum over at `Home Assistant <https://community.home-assistant.io/c/third-party/appdaemon/21>`__
-- We also have an active discord server `here <https://discord.gg/qN7c7JcFjk>`__ - please join us for tips and tricks, AppDaemon discussions and general home automation!
+If you have a question or need support, the following resources can help you:
+
+- The dedicated `Home Assistant Community forum <https://community.home-assistant.io/c/third-party/appdaemon/21>`__
+- Our `Discord server <https://discord.gg/qN7c7JcFjk>`_, where you are invited to join us for tips and tricks, AppDaemon discussions and general home automation!
 
 Developers
 ==========
@@ -39,7 +41,10 @@ AppDaemon is developed and maintained by a small team of hard working folks:
 - `Andrew Cockburn <https://github.com/acockburn>`__ - AppDaemon founder, Chief Architect and Benevolent Dictator For Life.
 - `Odianosen Ejale <https://github.com/Odianosen25>`__ - Core & MQTT Development and maintenance, fixer and tester.
 
-Special thanks to `Carlo Mien <https://github.com/mion00>`__ for design and configuration of our CI Pipeline and project packaging
+Contributors
+^^^^^^^^^^^^
+
+Special thanks to `Carlo Mion <https://github.com/mion00>`__ for the design and configuration of our CI pipeline and project packaging.
 
 With thanks to previous members of the team:
 
@@ -49,14 +54,15 @@ With thanks to previous members of the team:
 - Daniel Lashua
 
 Contents:
+=========
 
 .. toctree::
    :maxdepth: 1
 
    INSTALL
    CONFIGURE
-   HASS_TUTORIAL
    DOCKER_TUTORIAL
+   HASS_TUTORIAL
    APPGUIDE
    COMMUNITY_TUTORIALS
    AD_API_REFERENCE


### PR DESCRIPTION
## Description
Some updates to the `installation` and `configuration` sections, fixing some typos and rewording some paragraphs so they can be better understood by newcomers.
I added a custom stylesheet, inspired by https://github.com/OpenShot/openshot-qt/pull/1272, to render the tables as responsive elements, wrapping the text content within.

I found out that ReadTheDocs can preview the changes from a PR, this may come in handy to preview them before merging in `dev`: https://docs.readthedocs.io/en/stable/guides/pull-requests.html