### PR TITLE
Configure ruff and remove flake8

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,9 +1,0 @@
-[flake8]
-# Increase from the default 79
-max-line-length = 500
-
-extend-ignore = E203, E266
-# E203 whitespace before ‘,’, ‘;’, or ‘:’
-# E266 too many leading ‘#’ for block comment
-
-max-complexity=18

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,28 +4,13 @@ repos:
   hooks:
     - id: end-of-file-fixer
     - id: trailing-whitespace
+- repo: https://github.com/charliermarsh/ruff-pre-commit
+  rev: 'v0.0.255'
+  hooks:
+    - id: ruff
+      args: [--fix, --exit-non-zero-on-fix]
 - repo: https://github.com/ambv/black
   rev: 23.1.0
   hooks:
     - id: black
       language_version: python3
-- repo: https://github.com/PyCQA/flake8
-  rev: 6.0.0
-  hooks:
-    - id: flake8
-# If pyproject.toml is modified, run pip-compile to pin the version of dependencies inside requirements.txt files
-#- repo: https://github.com/jazzband/pip-tools
-#  rev: 6.12.3
-#  hooks:
-#    - id: pip-compile
-#      name: pip-compile pyproject.toml
-#      args: [--resolver=backtracking, pyproject.toml]
-#      files: ^requirements\.txt|pyproject\.toml$
-#    - id: pip-compile
-#      name: pip-compile pyproject.toml --extra=dev
-#      args: [--extra=dev, --output-file=dev-requirements.txt, --resolver=backtracking, pyproject.toml]
-#      files: ^dev-requirements\.txt|pyproject\.toml$
-#    - id: pip-compile
-#      name: pip-compile pyproject.toml --extra=doc
-#      args: [--extra=doc, --output-file=doc-requirements.txt, --resolver=backtracking, pyproject.toml]
-#      files: ^doc-requirements\.txt|pyproject\.toml$

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,8 +106,10 @@ select = ["E", "F"]
 ignore = []
 
 # Allow autofix for all enabled rules (when `--fix`) is provided.
-fixable = ["A", "B", "C", "D", "E", "F", "UP"]
+fixable = ["E", "F", "UP"]
 unfixable = []
+
+src = ["appdaemon"]
 
 # Exclude a variety of commonly ignored directories.
 exclude = [
@@ -134,7 +136,7 @@ exclude = [
 ]
 per-file-ignores = {}
 
-line-length = 120
+line-length = 500
 
 # Allow unused variables when underscore-prefixed.
 dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,8 @@ dev = [
     "flake8 ~= 6.0.0",
     "black ~= 23.1.0",
     'pre-commit ~= 3.1.1; python_version>"3.7"',  # pre-commit does not support Python < 3.8
-    "pytest ~= 7.2.1"
+    "pytest ~= 7.2.1",
+    "ruff ~= 0.0.255"
 ]
 
 # Dependencies required to build the documentation using sphinx
@@ -96,3 +97,51 @@ addopts = [
 # black configuration
 [tool.black]
 line-length = 120
+
+# Ruff
+
+[tool.ruff]
+# Enable pycodestyle (`E`) and Pyflakes (`F`) codes by default.
+select = ["E", "F"]
+ignore = []
+
+# Allow autofix for all enabled rules (when `--fix`) is provided.
+fixable = ["A", "B", "C", "D", "E", "F", "UP"]
+unfixable = []
+
+# Exclude a variety of commonly ignored directories.
+exclude = [
+    ".bzr",
+    ".direnv",
+    ".eggs",
+    ".git",
+    ".hg",
+    ".mypy_cache",
+    ".nox",
+    ".pants.d",
+    ".pytype",
+    ".ruff_cache",
+    ".svn",
+    ".tox",
+    ".venv",
+    "__pypackages__",
+    "_build",
+    "buck-out",
+    "build",
+    "dist",
+    "node_modules",
+    "venv",
+]
+per-file-ignores = {}
+
+line-length = 120
+
+# Allow unused variables when underscore-prefixed.
+dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+
+# Assume Python 3.8.
+target-version = "py38"
+
+[tool.ruff.mccabe]
+# Unlike Flake8, default to a complexity level of 10.
+max-complexity = 10


### PR DESCRIPTION
Moving to Ruff initially as a replacement for flake8 but later we can add a bunch of other stuff