### PR TITLE
Fix return type for get_ad_api()

### DIFF
--- a/appdaemon/adbase.py
+++ b/appdaemon/adbase.py
@@ -97,7 +97,7 @@ class ADBase:
     # API/Plugin
     #
 
-    def get_ad_api(self) -> Callable:
+    def get_ad_api(self) -> adapi.ADAPI:
         api = adapi.ADAPI(
             self.AD,
             self.name,


### PR DESCRIPTION
The ADAPI class is a better return value than Callable and it also broke the IDE's ability to properly use IntelliSense.