### PR TITLE
remove extra "_" in input_datetime.yml static CSS

### DIFF
--- a/appdaemon/widgets/input_datetime.yaml
+++ b/appdaemon/widgets/input_datetime.yaml
@@ -15,7 +15,7 @@ static_css:
   date_value_style: $input_datetime_date_style
   time_value_style: $input_datetime_time_style
   widget_style: $input_datetime_widget_style
-  container_style: $input_datetime__container_style
+  container_style: $input_datetime_container_style
 post_service:
   service: input_datetime/set_datetime
   entity_id: "{{entity}}"


### PR DESCRIPTION
 ```container_style: $input_datetime_container_style``` contained an extra underscore which prevented CSS styling users tried to pass from actually being used.