### PR TITLE
Fix for events listening to event

### DIFF
--- a/appdaemon/app_management.py
+++ b/appdaemon/app_management.py
@@ -362,7 +362,7 @@ class AppManagement:
             )
             await self.increase_inactive_apps(name)
 
-    def init_plugin_object(self, name, object):
+    def init_plugin_object(self, name: str, object: object, use_dictionary_unpacking: bool = False) -> None:
         self.objects[name] = {
             "type": "plugin",
             "object": object,
@@ -370,6 +370,7 @@ class AppManagement:
             "pin_app": False,
             "pin_thread": -1,
             "running": False,
+            "use_dictionary_unpacking": use_dictionary_unpacking,
         }
 
     def init_sequence_object(self, name, object):

--- a/appdaemon/plugin_management.py
+++ b/appdaemon/plugin_management.py
@@ -74,6 +74,9 @@ class Plugins:
                     if "refresh_timeout" not in self.plugins[name]:
                         self.plugins[name]["refresh_timeout"] = 30
 
+                    if "use_dictionary_unpacking" not in self.plugins[name]:
+                        self.plugins[name]["use_dictionary_unpacking"] = True
+
                     basename = self.plugins[name]["type"]
                     type = self.plugins[name]["type"]
                     module_name = "{}plugin".format(basename)
@@ -122,7 +125,8 @@ class Plugins:
                         #
                         # Create app entry for the plugin so we can listen_state/event
                         #
-                        self.AD.app_management.init_plugin_object(name, plugin)
+                        use_dictionary_unpacking = self.plugins[name]["use_dictionary_unpacking"]
+                        self.AD.app_management.init_plugin_object(name, plugin, use_dictionary_unpacking)
 
                         self.AD.loop.create_task(plugin.get_updates())
                     except Exception:
@@ -266,7 +270,14 @@ class Plugins:
                         "admin",
                         "plugin.{}".format(name),
                         "active",
-                        {"bytes_sent_ps": 0, "bytes_recv_ps": 0, "requests_sent_ps": 0, "updates_recv_ps": 0},
+                        {
+                            "bytes_sent_ps": 0,
+                            "bytes_recv_ps": 0,
+                            "requests_sent_ps": 0,
+                            "updates_recv_ps": 0,
+                            "totalcallbacks": 0,
+                            "instancecallbacks": 0,
+                        },
                     )
 
                     self.logger.info("Got initial state from namespace %s", namespace)

--- a/appdaemon/threading.py
+++ b/appdaemon/threading.py
@@ -870,11 +870,19 @@ class Threading:
         if "__silent" in args["kwargs"]:
             silent = args["kwargs"]["__silent"]
 
-        app_args = self.AD.app_management.app_config[args["name"]]
-        if "use_dictionary_unpacking" in app_args:
-            use_dictionary_unpacking = app_args["use_dictionary_unpacking"]
-        else:
-            use_dictionary_unpacking = self.AD.use_dictionary_unpacking
+        # first we get AD's level directive
+        use_dictionary_unpacking = self.AD.use_dictionary_unpacking
+
+        # app level config takes priority so processed after AD's
+        if args["name"] in self.AD.app_management.app_config:
+            app_args = self.AD.app_management.app_config[args["name"]]
+
+            if "use_dictionary_unpacking" in app_args:
+                use_dictionary_unpacking = app_args["use_dictionary_unpacking"]
+
+        elif args["name"] in self.AD.app_management.objects:
+            # plugin's directive is to use dictionary unpacking
+            use_dictionary_unpacking = self.AD.app_management.objects[args["name"]]["use_dictionary_unpacking"]
 
         app = await self.AD.app_management.get_app_instance(name, objectid)
         if app is not None:


### PR DESCRIPTION
This fixes an issue whereby due to the new dictionary unpacking, it broke the plugins ability to listen to event code.

So this fixes it, and makes it that the default behaviour for plugins is to use the dict unpacking and the user has to forcefully use otherwise.