### PR TITLE
Fixes an issue with event callback filtering

### DIFF
--- a/appdaemon/events.py
+++ b/appdaemon/events.py
@@ -330,6 +330,7 @@ class Events:
                                         _run = False
                                 else:
                                     _run = False
+                                    break
 
                             if data["event_type"] == "__AD_LOG_EVENT":
                                 if (

--- a/appdaemon/events.py
+++ b/appdaemon/events.py
@@ -328,6 +328,8 @@ class Events:
                                             _run = False
                                     elif match_val != event_val:
                                         _run = False
+                                else:
+                                    _run = False
 
                             if data["event_type"] == "__AD_LOG_EVENT":
                                 if (


### PR DESCRIPTION
This fixes a bug where an event callback would run if the event didn't contain a keyword argument that is specified as a filter in the listen_event() method.