### PR TITLE
Babel package

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.woff2 binary

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     'aiohttp ~= 3.8.4',
     'aiohttp_jinja2 ~= 1.5.1',
     'astral ~= 3.2',
+    'babel ~= 2.12.1',
     'bcrypt ~= 4.0.1',
     'deepdiff == 6.3.0',
     'feedparser ~= 6.0.10',

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,8 @@ async-timeout==4.0.2
     # via aiohttp
 attrs==23.1.0
     # via aiohttp
+babel==2.12.1
+    # via appdaemon (pyproject.toml)
 bcrypt==4.0.1
     # via appdaemon (pyproject.toml)
 bidict==0.22.1


### PR DESCRIPTION
Adds Babel as requirement to enable i18n  off apps, as seen in [joBr99/nspanel-lovelace-ui](https://github.com/joBr99/nspanel-lovelace-ui/blob/main/docs/prepare_ha.md)

I have been adding it through an extra Dockerfile import for a while and it is working fine. 