### PR TITLE
Async/non-async http endpoints receive the same args

### DIFF
--- a/appdaemon/adapi.py
+++ b/appdaemon/adapi.py
@@ -1145,14 +1145,16 @@ class ADAPI:
         Examples:
             It should be noted that the register function, should return a string (can be empty),
             and an HTTP OK status response (e.g., `200`. If this is not added as a returned response,
-            the function will generate an error each time it is processed.
+            the function will generate an error each time it is processed. If the POST request
+            contains JSON data, the decoded data will be passed as the argument to the callback.
+            Otherwise the callback argument will contain the query string. A `request` kwarg contains
+            the http request object.
 
             >>> self.register_endpoint(self.my_callback)
             >>> self.register_endpoint(self.alexa_cb, "alexa")
 
-            >>> async def alexa_cb(self, request, kwargs):
-            >>>     data = await request.json()
-            >>>     self.log(data)
+            >>> async def alexa_cb(self, json_obj, kwargs):
+            >>>     self.log(json_obj)
             >>>     response = {"message": "Hello World"}
             >>>     return response, 200
 

--- a/appdaemon/http.py
+++ b/appdaemon/http.py
@@ -911,7 +911,7 @@ class HTTP:
 
     async def dispatch_app_endpoint(self, endpoint, request):
         callback = None
-        rargs = {}
+        rargs = {"request": request}
         appname = None
 
         for name in self.app_endpoints:
@@ -948,9 +948,8 @@ class HTTP:
                     return await callback(args, rargs)
             else:
                 if use_dictionary_unpacking is True:
-                    return await utils.run_in_executor(self, callback, args, request=request, **rargs)
+                    return await utils.run_in_executor(self, callback, args, **rargs)
                 else:
-                    rargs["request"] = request
                     return await utils.run_in_executor(self, callback, args, rargs)
         else:
             return "", 404

--- a/docs/APPGUIDE.rst
+++ b/docs/APPGUIDE.rst
@@ -2190,11 +2190,9 @@ Here is an example of an App using the API:
         def initialize(self):
             self.register_endpoint(my_callback, "test_endpoint")
 
-        def my_callback(self, args, cb_args):
+        def my_callback(self, json_obj, cb_args):
 
-            data = await request.json()
-
-            self.log(data)
+            self.log(json_obj)
 
             response = {"message": "Hello World"}
 


### PR DESCRIPTION
112a0337c410a60ca2df926a97eae7eebb4a9bc0 removed the http `request` object from the async http endpoint callback signature. In my use-case, the `request` object is needed to access the client IP address. The `request` object was added back in ece502d257c1a53110c0837a6819eafeab3c11d3 for non-async callbacks. This PR adds access to the `request` object for both async and non-async calls.

I've also updated the documentation to reflect the changes from ece502d257c1a53110c0837a6819eafeab3c11d3.

Fixes #1818