### PR TITLE
Fix ignored hostname on http server, fix ipv6 support

### DIFF
--- a/appdaemon/http.py
+++ b/appdaemon/http.py
@@ -164,10 +164,9 @@ class HTTP:
         try:
             url = urlparse(self.url)
 
-            net = url.netloc.split(":")
-            self.host = net[0]
+            self.host = url.hostname
             try:
-                self.port = net[1]
+                self.port = url.port
             except IndexError:
                 self.port = 80
 
@@ -367,7 +366,7 @@ class HTTP:
 
         self.runner = web.AppRunner(self.app)
         await self.runner.setup()
-        site = web.TCPSite(self.runner, "0.0.0.0", int(self.port), ssl_context=self.context)
+        site = web.TCPSite(self.runner, self.host, int(self.port), ssl_context=self.context)
         await site.start()
 
     async def stop_server(self):


### PR DESCRIPTION
The hostname that is set in the config via

```
http:
  url: http://example.com:5050
```

is ignored. Instead the http server binds to "0.0.0.0".

Also this breaks IPv6 compatibility: When i tried to set the host to http://[::1]:5050, the port isnt parsed correctly because of the 
`url.netloc.split(":")`
This will result in appdaemon not starting.
