### PR TITLE
Fix for issue #1857

### DIFF
--- a/appdaemon/widgets/baseicon/baseicon.js
+++ b/appdaemon/widgets/baseicon/baseicon.js
@@ -86,7 +86,7 @@ function baseicon(widget_id, url, skin, parameters)
             {
                 self.set_icon(self, "icon", self.parameters.icons.default.icon);
                 self.set_field(self, "icon_style", self.parameters.icons.default.style);
-                set_service_call(self, self.parameters.default);
+                set_service_call(self, self.parameters.icons.default);
             }
             else
             {


### PR DESCRIPTION
Updated baseicon.js to pass correct second argument to set_service_call in function set_view when the default icon is used.