### PR TITLE
Fix bug in path checking.

### DIFF
--- a/appdaemon/app_management.py
+++ b/appdaemon/app_management.py
@@ -401,7 +401,7 @@ class AppManagement:
 
         for root, subdirs, files in await utils.run_in_executor(self, os.walk, self.AD.app_dir):
             subdirs[:] = [d for d in subdirs if d not in self.AD.exclude_dirs and "." not in d]
-            if root[-11:] != "__pycache__" and root[0] != ".":
+            if utils.is_valid_root_path(root):
                 for file in files:
                     if file[-5:] == self.ext and file[0] != ".":
                         path = os.path.join(root, file)
@@ -544,7 +544,7 @@ class AppManagement:
         later_files["deleted"] = []
         for root, subdirs, files in os.walk(self.AD.app_dir):
             subdirs[:] = [d for d in subdirs if d not in self.AD.exclude_dirs and "." not in d]
-            if root[-11:] != "__pycache__" and root[0] != ".":
+            if utils.is_valid_root_path(root):
                 for file in files:
                     if file[-5:] == self.ext and file[0] != ".":
                         path = os.path.join(root, file)
@@ -910,7 +910,7 @@ class AppManagement:
                 subdirs[:] = [d for d in subdirs if d not in self.AD.exclude_dirs and "." not in d]
 
                 if self.AD.import_method == "normal":
-                    if root[-11:] != "__pycache__" and root[0] != ".":
+                    if utils.is_valid_root_path(root):
                         if root not in self.module_dirs:
                             self.logger.info("Adding %s to module import path", root)
                             sys.path.insert(0, root)

--- a/appdaemon/utils.py
+++ b/appdaemon/utils.py
@@ -424,6 +424,11 @@ def find_owner(filename):
     return pwd.getpwuid(os.stat(filename).st_uid).pw_name
 
 
+def is_valid_root_path(root: str) -> bool:
+    root = os.path.basename(root)
+    return root != "__pycache__" and not root.startswith(".")
+
+
 def check_path(type, logger, inpath, pathtype="directory", permissions=None):  # noqa: C901
     # disable checks for windows platform
 


### PR DESCRIPTION
I believe the intention here is to skip directories named `__pycache__` and that begin with '.' but in that case, this incorrectly uses `root[0]` instead of the first character of the name of the last path element, and was causing strange behaviour when launching with `appdaemon -c .`, which I think is probably a common enough first experience when attempting local development.

P.S. Thanks for building this package!