### PR TITLE
Add optional `silent` parameter to `cancel_listen_state()`

### DIFF
--- a/appdaemon/adapi.py
+++ b/appdaemon/adapi.py
@@ -1413,7 +1413,7 @@ class ADAPI:
             return await self.get_entity_api(namespace, entity_id).listen_state(callback, **kwargs)
 
     @utils.sync_wrapper
-    async def cancel_listen_state(self, handle: str) -> bool:
+    async def cancel_listen_state(self, handle: str, silent=False) -> bool:
         """Cancels a ``listen_state()`` callback.
 
         This will mean that the App will no longer be notified for the specific
@@ -1422,6 +1422,7 @@ class ADAPI:
 
         Args:
             handle: The handle returned when the ``listen_state()`` call was made.
+            silent (bool, optional): If ``True``, no warning will be issued if the handle is not found.
 
         Returns:
             Boolean.
@@ -1429,9 +1430,13 @@ class ADAPI:
         Examples:
             >>> self.cancel_listen_state(self.office_light_handle)
 
+            Don't display a warning if the handle is not found.
+
+            >>> self.cancel_listen_state(self.dummy_handle, silent=True)
+
         """
         self.logger.debug("Canceling listen_state for %s", self.name)
-        return await self.AD.state.cancel_state_callback(handle, self.name)
+        return await self.AD.state.cancel_state_callback(handle, self.name, silent)
 
     @utils.sync_wrapper
     async def info_listen_state(self, handle: str) -> dict:

--- a/appdaemon/state.py
+++ b/appdaemon/state.py
@@ -286,7 +286,7 @@ class State:
         else:
             return None
 
-    async def cancel_state_callback(self, handle, name):
+    async def cancel_state_callback(self, handle, name, silent=False):
         executed = False
         async with self.AD.callbacks.callbacks_lock:
             if name in self.AD.callbacks.callbacks and handle in self.AD.callbacks.callbacks[name]:
@@ -297,7 +297,7 @@ class State:
             if name in self.AD.callbacks.callbacks and self.AD.callbacks.callbacks[name] == {}:
                 del self.AD.callbacks.callbacks[name]
 
-        if not executed:
+        if not executed and not silent:
             self.logger.warning(
                 "Invalid callback handle '{}' in cancel_state_callback() from app {}".format(handle, name)
             )


### PR DESCRIPTION
## Description

This PR adds an optional `silent` parameter to the `cancel_listen_state()` method. If `silent` is set to `True`, no warning will be issued if the handle is not found.

Closes: #2007

## Manual testing

I tested this PR with the following app:

```python
import hassapi as hass

class Test(hass.Hass):
    def initialize(self):
        self.cancel_listen_state('dummy-handle-1', silent=True)
        self.cancel_listen_state('dummy-handle-2', silent=False)
        self.cancel_listen_state('dummy-handle-3')
```

It produced the following output:

```console
2024-05-09 22:26:53.918482 INFO AppDaemon: Calling initialize() for test
2024-05-09 22:26:53.919529 WARNING AppDaemon: Invalid callback handle 'dummy-handle-2' in cancel_state_callback() from app test
2024-05-09 22:26:53.919943 WARNING AppDaemon: Invalid callback handle 'dummy-handle-3' in cancel_state_callback() from app test
2024-05-09 22:26:53.920415 INFO AppDaemon: App initialization complete
```

As expected, no warning is issued for the `dummy-handle-1` handle.