### PR TITLE
docstrings, type hints, and import sorting

### DIFF
--- a/appdaemon/__main__.py
+++ b/appdaemon/__main__.py
@@ -15,13 +15,13 @@ import platform
 import signal
 import sys
 
-import appdaemon.appdaemon as ad
-import appdaemon.http as adhttp
-import appdaemon.logging as logging
-import appdaemon.utils as utils
 import pytz
 
+import appdaemon.appdaemon as ad
+import appdaemon.utils as utils
 from appdaemon.app_management import UpdateMode
+from appdaemon.http import HTTP
+from appdaemon.logging import Logging
 
 try:
     import pid
@@ -38,6 +38,8 @@ class ADMain:
     """
     Class to encapsulate all main() functionality.
     """
+
+    logging: Logging
 
     def __init__(self):
         """Constructor."""
@@ -104,7 +106,7 @@ class ADMain:
             self.http_object.stop()
 
     # noinspection PyBroadException,PyBroadException
-    def run(self, appdaemon, hadashboard, admin, aui, api, http):
+    def run(self, appdaemon: ad.AppDaemon, hadashboard, admin, aui, api, http):
         """Start AppDaemon up after initial argument parsing.
 
         Args:
@@ -126,7 +128,7 @@ class ADMain:
                 self.logger.info("Running AD using uvloop")
                 uvloop.install()
 
-            loop = asyncio.get_event_loop()
+            loop: asyncio.BaseEventLoop = asyncio.get_event_loop()
 
             # Initialize AppDaemon
 
@@ -138,7 +140,7 @@ class ADMain:
                 hadashboard is not None or admin is not None or aui is not None or api is not False
             ):
                 self.logger.info("Initializing HTTP")
-                self.http_object = adhttp.HTTP(
+                self.http_object = HTTP(
                     self.AD,
                     loop,
                     self.logging,
@@ -357,7 +359,7 @@ class ADMain:
         else:
             logs = {}
 
-        self.logging = logging.Logging(logs, args.debug)
+        self.logging = Logging(logs, args.debug)
         self.logger = self.logging.get_logger()
 
         if "time_zone" in config["appdaemon"]:

--- a/appdaemon/adapi.py
+++ b/appdaemon/adapi.py
@@ -1,18 +1,19 @@
-from datetime import timedelta
-from copy import deepcopy
-from typing import Any, Optional, Callable, Union
-from asyncio import Future
-
 import asyncio
 import datetime as dt
 import inspect
 import re
 import uuid
+from asyncio import Future
+from copy import deepcopy
+from datetime import timedelta
+from typing import Any, Callable, Dict, Optional, Union
+
 import iso8601
 
 from appdaemon import utils
 from appdaemon.appdaemon import AppDaemon
 from appdaemon.entity import Entity
+from appdaemon.logging import Logging
 
 
 class ADAPI:
@@ -22,10 +23,32 @@ class ADAPI:
 
     """
 
+    AD: AppDaemon
+    """Reference to the top-level AppDaemon container object
+    """
+    name: str
+    """The app name, which is set by the top-level key in the YAML file
+    """
+    _logging: Logging
+    """Reference to the Logging subsystem object
+    """
+    args: Dict[str, Any]
+    """The arguments provided in this app's YAML config file
+    """
+
     #
     # Internal parameters
     #
-    def __init__(self, ad: AppDaemon, name, logging_obj, args, config, app_config, global_vars):
+    def __init__(
+        self,
+        ad: AppDaemon,
+        name: str,
+        logging_obj: Logging,
+        args: Dict[str, Any],
+        config: Dict[str, Any],
+        app_config,
+        global_vars,
+    ):
         # Store args
 
         self.AD = ad
@@ -33,6 +56,7 @@ class ADAPI:
         self._logging = logging_obj
         self.config = config
         self.app_config = app_config
+        # same as self.AD.app_management.app_config
         self.args = deepcopy(args)
         self.app_dir = self.AD.app_dir
         self.config_dir = self.AD.config_dir
@@ -58,7 +82,7 @@ class ADAPI:
     @staticmethod
     def _sub_stack(msg):
         # If msg is a data structure of some type, don't sub
-        if type(msg) is str:
+        if isinstance(msg, str):
             stack = inspect.stack()
             if msg.find("__module__") != -1:
                 msg = msg.replace("__module__", stack[2][1])
@@ -2494,9 +2518,9 @@ class ADAPI:
             >>> handle = self.run_once(self.run_once_c, "sunrise + 01:00:00")
 
         """
-        if type(start) == dt.time:
+        if isinstance(start, dt.time):
             when = start
-        elif type(start) == str:
+        elif isinstance(start, str):
             start_time_obj = await self.AD.sched._parse_time(start, self.name)
             when = start_time_obj["datetime"].time()
         else:
@@ -2571,9 +2595,9 @@ class ADAPI:
             >>> handle = self.run_at(self.run_at_c, "sunrise + 01:00:00")
 
         """
-        if type(start) == dt.datetime:
+        if isinstance(start, dt.datetime):
             when = start
-        elif type(start) == str:
+        elif isinstance(start, str):
             start_time_obj = await self.AD.sched._parse_time(start, self.name)
             when = start_time_obj["datetime"]
         else:
@@ -2644,9 +2668,9 @@ class ADAPI:
         """
         info = None
         when = None
-        if type(start) == dt.time:
+        if isinstance(start, dt.time):
             when = start
-        elif type(start) == str:
+        elif isinstance(start, str):
             info = await self.AD.sched._parse_time(start, self.name)
         else:
             raise ValueError("Invalid type for start")

--- a/appdaemon/admin.py
+++ b/appdaemon/admin.py
@@ -1,14 +1,17 @@
 import os
 import traceback
+from typing import TYPE_CHECKING
 
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 
 import appdaemon.utils as utils
-from appdaemon.appdaemon import AppDaemon
+
+if TYPE_CHECKING:
+    from appdaemon.appdaemon import AppDaemon
 
 
 class Admin:
-    def __init__(self, config_dir, logger, ad: AppDaemon, **kwargs):
+    def __init__(self, config_dir, logger, ad: "AppDaemon", **kwargs):
         #
         # Set Defaults
         #

--- a/appdaemon/admin_loop.py
+++ b/appdaemon/admin_loop.py
@@ -1,9 +1,23 @@
 import asyncio
-from appdaemon.appdaemon import AppDaemon
+from logging import Logger
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from appdaemon.appdaemon import AppDaemon
 
 
 class AdminLoop:
-    def __init__(self, ad: AppDaemon):
+    """Called by :meth:`~appdaemon.appdaemon.AppDaemon.register_http`. Loop timed with :attr:`~appdaemon.AppDaemon.admin_delay`"""
+
+    AD: "AppDaemon"
+    """Reference to the AppDaemon container object
+    """
+    stopping: bool
+    logger: Logger
+    """Standard python logger named ``AppDaemon._admin_loop``
+    """
+
+    def __init__(self, ad: "AppDaemon"):
         self.AD = ad
         self.stopping = False
         self.logger = ad.logging.get_child("_admin_loop")
@@ -13,6 +27,7 @@ class AdminLoop:
         self.stopping = True
 
     async def loop(self):
+        """Handles calling :meth:`~.threading.Threading.get_callback_update` and :meth:`~.threading.Threading.get_q_update`"""
         while not self.stopping:
             if self.AD.http.stats_update != "none" and self.AD.sched is not None:
                 await self.AD.threading.get_callback_update()

--- a/appdaemon/appdaemon.py
+++ b/appdaemon/appdaemon.py
@@ -1,11 +1,37 @@
-import concurrent.futures
 import os
 import os.path
 import threading
+from asyncio import BaseEventLoop
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from typing import TYPE_CHECKING, Union
+
+import appdaemon.utils as utils
+from appdaemon.admin_loop import AdminLoop
+from appdaemon.app_management import AppManagement
+from appdaemon.callbacks import Callbacks
+from appdaemon.events import Events
+from appdaemon.futures import Futures
+from appdaemon.plugin_management import Plugins
+from appdaemon.scheduler import Scheduler
+from appdaemon.sequences import Sequences
+from appdaemon.services import Services
+from appdaemon.state import State
+from appdaemon.thread_async import ThreadAsync
+from appdaemon.threading import Threading
+from appdaemon.utility_loop import Utility
+
+if TYPE_CHECKING:
+    from appdaemon.http import HTTP
+    from appdaemon.logging import Logging
 
 
 class AppDaemon:
     """Top-level container for the subsystem objects. This gets passed to the subsystem objects and stored in them as the ``self.AD`` attribute.
+
+    Asyncio:
+
+    :class:`~concurrent.futures.ThreadPoolExecutor`
 
     Subsystems:
 
@@ -15,50 +41,75 @@ class AppDaemon:
 
         * - Attribute
           - Object
+        * - ``app_management``
+          - :class:`~.app_management.AppManagement`
+        * - ``callbacks``
+          - :class:`~.callbacks.Callbacks`
+        * - ``events``
+          - :class:`~.events.Events`
+        * - ``futures``
+          - :class:`~.futures.Futures`
+        * - ``http``
+          - :class:`~.http.HTTP`
+        * - ``plugins``
+          - :class:`~.plugin_management.Plugins`
+        * - ``scheduler``
+          - :class:`~.scheduler.Scheduler`
         * - ``services``
           - :class:`~.services.Services`
         * - ``sequences``
           - :class:`~.sequences.Sequences`
         * - ``state``
           - :class:`~.state.State`
-        * - ``events``
-          - :class:`~.events.Events`
-        * - ``callbacks``
-          - :class:`~.callbacks.Callbacks`
-        * - ``futures``
-          - :class:`~.futures.Futures`
-        * - ``app_management``
-          - :class:`~.app_management.AppManagement`
         * - ``threading``
           - :class:`~.threading.Threading`
-        * - ``executor``
-          - :class:`~concurrent.futures.ThreadPoolExecutor`
-        * - ``plugins``
-          - :class:`~.plugin_management.Plugins`
         * - ``utility``
           - :class:`~.utility_loop.Utility`
 
+
     """
 
-    def __init__(self, logging, loop, **kwargs):
-        #
-        # Import various AppDaemon bits and pieces now to avoid circular import
-        #
+    # asyncio
+    loop: BaseEventLoop
+    """Main asyncio event loop
+    """
+    executor: ThreadPoolExecutor
+    """Executes functions from a pool of async threads. Configured with the ``threadpool_workers`` key. Defaults to 10.
+    """
 
-        import appdaemon.app_management as apps
-        import appdaemon.callbacks as callbacks
-        import appdaemon.events as events
-        import appdaemon.futures as futures
-        import appdaemon.plugin_management as plugins
-        import appdaemon.scheduler as scheduler
-        import appdaemon.sequences as sequences
-        import appdaemon.services as services
-        import appdaemon.state as state
-        import appdaemon.thread_async as appq
-        import appdaemon.threading
-        import appdaemon.utility_loop as utility
-        import appdaemon.utils as utils
+    # subsystems
+    app_management: AppManagement
+    callbacks: Callbacks
+    events: Events
+    futures: Futures
+    http: "HTTP"
+    logging: "Logging"
+    plugins: Plugins
+    scheduler: Scheduler
+    services: Services
+    sequences: Sequences
+    state: State
+    threading: Threading
+    utility: Utility
 
+    # shut down flag
+    stopping: bool
+
+    # settings
+    app_dir: Union[str, Path]
+    """Defined in the main YAML config under ``appdaemon.app_dir``. Defaults to ``./apps``
+    """
+    config_dir: Union[str, Path]
+    """Path to the AppDaemon configuration files. Defaults to the first folder that has ``./apps``
+
+    - ``~/.homeassistant``
+    - ``/etc/appdaemon``
+    """
+    apps: bool
+    """Flag for whether ``disable_apps`` was set in the AppDaemon config
+    """
+
+    def __init__(self, logging: "Logging", loop: BaseEventLoop, **kwargs):
         self.logging = logging
         self.logging.register_ad(self)
         self.logger = logging.get_logger()
@@ -71,10 +122,6 @@ class AppDaemon:
         self.booted = "booting"
         self.config["ad_version"] = utils.__version__
         self.check_app_updates_profile = ""
-
-        self.was_dst = False
-
-        self.last_state = None
 
         self.executor = None
         self.loop = None
@@ -223,37 +270,37 @@ class AppDaemon:
         #
         # Set up services
         #
-        self.services = services.Services(self)
+        self.services = Services(self)
 
         #
         # Set up sequences
         #
-        self.sequences = sequences.Sequences(self)
+        self.sequences = Sequences(self)
 
         #
         # Set up scheduler
         #
-        self.sched = scheduler.Scheduler(self)
+        self.sched = Scheduler(self)
 
         #
         # Set up state
         #
-        self.state = state.State(self)
+        self.state = State(self)
 
         #
         # Set up events
         #
-        self.events = events.Events(self)
+        self.events = Events(self)
 
         #
         # Set up callbacks
         #
-        self.callbacks = callbacks.Callbacks(self)
+        self.callbacks = Callbacks(self)
 
         #
         # Set up futures
         #
-        self.futures = futures.Futures(self)
+        self.futures = Futures(self)
 
         if self.apps is True:
             if self.app_dir is None:
@@ -266,13 +313,16 @@ class AppDaemon:
             utils.check_path("config_dir", self.logger, self.config_dir, permissions="rwx")
             utils.check_path("appdir", self.logger, self.app_dir)
 
+            self.config_dir = os.path.abspath(self.config_dir)
+            self.app_dir = os.path.abspath(self.app_dir)
+
             # Initialize Apps
 
-            self.app_management = apps.AppManagement(self, self.use_toml)
+            self.app_management = AppManagement(self, self.use_toml)
 
             # threading setup
 
-            self.threading = appdaemon.threading.Threading(self, kwargs)
+            self.threading = Threading(self, kwargs)
 
         self.stopping = False
 
@@ -282,33 +332,34 @@ class AppDaemon:
         if "threadpool_workers" in kwargs:
             self.threadpool_workers = int(kwargs["threadpool_workers"])
 
-        self.executor = concurrent.futures.ThreadPoolExecutor(max_workers=self.threadpool_workers)
+        self.executor = ThreadPoolExecutor(max_workers=self.threadpool_workers)
 
         # Initialize Plugins
-
-        if "plugins" in kwargs:
-            args = kwargs["plugins"]
-        else:
-            args = None
-
-        self.plugins = plugins.Plugins(self, args)
+        args = kwargs.get("plugins", None)
+        self.plugins = Plugins(self, args)
 
         # Create thread_async Loop
-
         self.logger.debug("Starting thread_async loop")
-
         if self.apps is True:
-            self.thread_async = appq.ThreadAsync(self)
+            self.thread_async = ThreadAsync(self)
             loop.create_task(self.thread_async.loop())
 
         # Create utility loop
-
         self.logger.debug("Starting utility loop")
-
-        self.utility = utility.Utility(self)
+        self.utility = Utility(self)
         loop.create_task(self.utility.loop())
 
     def stop(self):
+        """Called by the signal handler to shut AD down.
+
+        Also stops
+
+        - :class:`~.admin_loop.AdminLoop`
+        - :class:`~.thread_async.ThreadAsync`
+        - :class:`~.scheduler.Scheduler`
+        - :class:`~.utility_loop.Utility`
+        - :class:`~.plugin_management.Plugins`
+        """
         self.stopping = True
         if self.admin_loop is not None:
             self.admin_loop.stop()
@@ -329,14 +380,14 @@ class AppDaemon:
     # Utilities
     #
 
-    def register_http(self, http):
-        import appdaemon.admin_loop as admin_loop
+    def register_http(self, http: "HTTP"):
+        """Sets the ``self.http`` attribute with a :class:`~.http.HTTP` object and starts the admin loop."""
 
-        self.http = http
+        self.http: "HTTP" = http
         # Create admin loop
 
         if http.old_admin is not None or http.admin is not None:
             self.logger.debug("Starting admin loop")
 
-            self.admin_loop = admin_loop.AdminLoop(self)
+            self.admin_loop = AdminLoop(self)
             self.loop.create_task(self.admin_loop.loop())

--- a/appdaemon/callbacks.py
+++ b/appdaemon/callbacks.py
@@ -1,19 +1,28 @@
 import asyncio
+from logging import Logger
+from typing import TYPE_CHECKING
 
 import appdaemon.utils as utils
-from appdaemon.appdaemon import AppDaemon
+
+if TYPE_CHECKING:
+    from appdaemon.appdaemon import AppDaemon
 
 
 class Callbacks:
-    """Subsystem container for events
+    """Container for storing callbacks. Modified by :class:`~.events.Events` and :class:`~.state.State`"""
 
-    Attributes:
-        AD: Reference to the AppDaemon container object
+    AD: "AppDaemon"
+    """Reference to the AppDaemon container object
+    """
+    logger: Logger
+    """Standard python logger named ``AppDaemon._callbacks``
+    """
+    diag: Logger
+    """Standard python logger named ``Diag``
     """
 
-    def __init__(self, ad: AppDaemon):
+    def __init__(self, ad: "AppDaemon"):
         self.AD = ad
-
         self.callbacks = {}
         self.callbacks_lock = asyncio.Lock()
         self.logger = ad.logging.get_child("_callbacks")
@@ -24,6 +33,7 @@ class Callbacks:
     #
 
     async def dump_callbacks(self):
+        """Dumps info about the callbacks to the ``Diag`` log"""
         async with self.callbacks_lock:
             if self.callbacks == {}:
                 self.diag.info("No callbacks")

--- a/appdaemon/dashboard.py
+++ b/appdaemon/dashboard.py
@@ -1,16 +1,17 @@
-import os
 import ast
-import re
-import yaml
-from jinja2 import Environment, BaseLoader, FileSystemLoader, select_autoescape
-import traceback
-import functools
-import time
 import cProfile
-import io
-import pstats
 import datetime
+import functools
+import io
+import os
+import pstats
+import re
+import time
+import traceback
 from collections import OrderedDict
+
+import yaml
+from jinja2 import BaseLoader, Environment, FileSystemLoader, select_autoescape
 
 import appdaemon.utils as ha
 
@@ -162,7 +163,7 @@ class Dashboard:
             for varline in fields:
                 if isinstance(fields[varline], dict):
                     fields[varline] = self._resolve_css_params(fields[varline], subs)
-                elif fields[varline] is not None and type(fields[varline]) == str:
+                elif fields[varline] is not None and isinstance(fields[varline], str):
                     _vars = variable.finditer(fields[varline])
                     for var in _vars:
                         subvar = var.group()[1:]

--- a/appdaemon/entity.py
+++ b/appdaemon/entity.py
@@ -1,13 +1,16 @@
-from appdaemon.appdaemon import AppDaemon
-from appdaemon.exceptions import TimeOutException
-import appdaemon.utils as utils
-
-from typing import Any, Optional, Callable, Union
-from logging import Logger
 import asyncio
 import uuid
-import iso8601
 from collections.abc import Iterable
+from logging import Logger
+from typing import TYPE_CHECKING, Any, Callable, Optional, Union
+
+import iso8601
+
+import appdaemon.utils as utils
+from appdaemon.exceptions import TimeOutException
+
+if TYPE_CHECKING:
+    from appdaemon.appdaemon import AppDaemon
 
 
 class EntityAttrs:
@@ -20,11 +23,12 @@ class EntityAttrs:
 
 
 class Entity:
+    AD: "AppDaemon"
+    name: str
+    logger: Logger
     states_attrs = EntityAttrs()
 
-    def __init__(self, logger: Logger, ad: AppDaemon, name: str, namespace: str, entity_id: str):
-        # Store args
-
+    def __init__(self, logger: Logger, ad: "AppDaemon", name: str, namespace: str, entity_id: str):
         self.AD = ad
         self.name = name
         self.logger = logger
@@ -434,7 +438,7 @@ class Entity:
     #
 
     @classmethod
-    def entity_api(cls, logger: Logger, ad: AppDaemon, name: str, namespace: str, entity: str):
+    def entity_api(cls, logger: Logger, ad: "AppDaemon", name: str, namespace: str, entity: str):
         return cls(logger, ad, name, namespace, entity)
 
     #

--- a/appdaemon/events.py
+++ b/appdaemon/events.py
@@ -1,33 +1,29 @@
+import datetime
+import traceback
 import uuid
 from copy import deepcopy
-import traceback
-import datetime
+from logging import Logger
+from typing import TYPE_CHECKING, Any, Dict
 
-from appdaemon.appdaemon import AppDaemon
 import appdaemon.utils as utils
+
+if TYPE_CHECKING:
+    from appdaemon.appdaemon import AppDaemon
 
 
 class Events:
-    """Subsystem container for handling all events
+    """Subsystem container for handling all events"""
 
-    Attributes:
-        AD: Reference to the AppDaemon container object
+    AD: "AppDaemon"
+    """Reference to the top-level AppDaemon container object
+    """
+    logger: Logger
+    """Standard python logger named ``AppDaemon._events``
     """
 
-    AD: AppDaemon
-
-    def __init__(self, ad: AppDaemon):
-        """Constructor.
-
-        Args:
-            ad: Reference to the AppDaemon object
-        """
-
+    def __init__(self, ad: "AppDaemon"):
         self.AD = ad
         self.logger = ad.logging.get_child("_events")
-        #
-        # Events
-        #
 
     async def add_event_callback(self, name, namespace, cb, event, **kwargs):
         """Adds a callback for an event which is called internally by apps.
@@ -134,12 +130,15 @@ class Events:
 
         return executed
 
-    async def info_event_callback(self, name, handle):
+    async def info_event_callback(self, name: str, handle: str):
         """Gets the information of an event callback.
 
         Args:
             name (str): Name of the app or subsystem.
-            handle: Previously supplied handle for the callback.
+            handle (str): Previously supplied handle for the callback.
+
+        Raises:
+            ValueError: an invalid name or handle was provided
 
         Returns:
             A dictionary of callback entries or rise a ``ValueError`` if an invalid handle is provided.
@@ -153,7 +152,7 @@ class Events:
             else:
                 raise ValueError("Invalid handle: {}".format(handle))
 
-    async def fire_event(self, namespace, event, **kwargs):
+    async def fire_event(self, namespace: str, event: str, **kwargs):
         """Fires an event.
 
         If the namespace does not have a plugin associated with it, the event will be fired locally.
@@ -181,7 +180,7 @@ class Events:
             # Just fire the event locally
             await self.AD.events.process_event(namespace, {"event_type": event, "data": kwargs})
 
-    async def process_event(self, namespace, data):
+    async def process_event(self, namespace: str, data: Dict[str, Any]):
         """Processes an event that has been received either locally or from a plugin.
 
         Args:
@@ -261,7 +260,7 @@ class Events:
             self.logger.warning(traceback.format_exc())
             self.logger.warning("-" * 60)
 
-    async def has_log_callback(self, name):
+    async def has_log_callback(self, name: str):
         """Returns ``True`` if the app has a log callback, ``False`` otherwise.
 
         Used to prevent callback loops. In the calling logic, if this function returns

--- a/appdaemon/futures.py
+++ b/appdaemon/futures.py
@@ -1,9 +1,20 @@
-from appdaemon.appdaemon import AppDaemon
 import functools
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from appdaemon.appdaemon import AppDaemon
 
 
 class Futures:
-    def __init__(self, ad: AppDaemon):
+    """Subsystem container for managing :class:`~asyncio.Future` objects
+
+    Attributes:
+        AD: Reference to the AppDaemon container object
+    """
+
+    AD: "AppDaemon"
+
+    def __init__(self, ad: "AppDaemon"):
         self.AD = ad
 
         self.futures = {}

--- a/appdaemon/scheduler.py
+++ b/appdaemon/scheduler.py
@@ -7,16 +7,25 @@ import traceback
 import uuid
 from collections import OrderedDict
 from datetime import timedelta
+from logging import Logger
+from typing import TYPE_CHECKING
 
 import pytz
 from astral.location import Location, LocationInfo
 
 import appdaemon.utils as utils
-from appdaemon.appdaemon import AppDaemon
+
+if TYPE_CHECKING:
+    from appdaemon.appdaemon import AppDaemon
 
 
 class Scheduler:
-    def __init__(self, ad: AppDaemon):
+    AD: "AppDaemon"
+    logger: Logger
+    error: Logger
+    diag: Logger
+
+    def __init__(self, ad: "AppDaemon"):
         self.AD = ad
 
         self.logger = ad.logging.get_child("_scheduler")

--- a/appdaemon/sequences.py
+++ b/appdaemon/sequences.py
@@ -1,11 +1,15 @@
-import uuid
 import asyncio
-import traceback
 import copy
+import traceback
+import uuid
+from logging import Logger
+from typing import TYPE_CHECKING
 
-from appdaemon.appdaemon import AppDaemon
 from appdaemon.entity import Entity
 from appdaemon.exceptions import TimeOutException
+
+if TYPE_CHECKING:
+    from appdaemon.appdaemon import AppDaemon
 
 
 class Sequences:
@@ -15,9 +19,10 @@ class Sequences:
         AD: Reference to the AppDaemon container object
     """
 
-    AD: AppDaemon
+    AD: "AppDaemon"
+    logger: Logger
 
-    def __init__(self, ad: AppDaemon):
+    def __init__(self, ad: "AppDaemon"):
         self.AD = ad
         self.logger = ad.logging.get_child("_sequences")
 

--- a/appdaemon/state.py
+++ b/appdaemon/state.py
@@ -1,11 +1,15 @@
-import uuid
-import traceback
-import os
-from copy import copy, deepcopy
 import datetime
+import os
+import traceback
+import uuid
+from copy import copy, deepcopy
+from logging import Logger
+from typing import TYPE_CHECKING
 
 import appdaemon.utils as utils
-from appdaemon.appdaemon import AppDaemon
+
+if TYPE_CHECKING:
+    from appdaemon.appdaemon import AppDaemon
 
 
 class State:
@@ -15,7 +19,10 @@ class State:
         AD: Reference to the AppDaemon container object
     """
 
-    def __init__(self, ad: AppDaemon):
+    AD: "AppDaemon"
+    logger: Logger
+
+    def __init__(self, ad: "AppDaemon"):
         self.AD = ad
 
         self.state = {"default": {}, "admin": {}, "rules": {}}

--- a/appdaemon/thread_async.py
+++ b/appdaemon/thread_async.py
@@ -1,7 +1,10 @@
 import asyncio
 import traceback
+from logging import Logger
+from typing import TYPE_CHECKING
 
-from appdaemon.appdaemon import AppDaemon
+if TYPE_CHECKING:
+    from appdaemon.appdaemon import AppDaemon
 
 
 class ThreadAsync:
@@ -9,14 +12,15 @@ class ThreadAsync:
     Module to translate from the thread world to the async world via queues
     """
 
-    def __init__(self, ad: AppDaemon):
+    AD: "AppDaemon"
+    stopping: bool
+    logging: Logger
+    appq: asyncio.Queue
+
+    def __init__(self, ad: "AppDaemon"):
         self.AD = ad
         self.stopping = False
         self.logger = ad.logging.get_child("_thread_async")
-        #
-        # Initial Setup
-        #
-
         self.appq = asyncio.Queue(maxsize=0)
 
     def stop(self):

--- a/appdaemon/threading.py
+++ b/appdaemon/threading.py
@@ -7,17 +7,44 @@ import sys
 import threading
 import traceback
 from datetime import timedelta
+from logging import Logger
 from queue import Queue
 from random import randint
+from threading import Thread
+from typing import TYPE_CHECKING, Dict, List, Optional, Union
 
 import iso8601
 
 from appdaemon import utils as utils
-from appdaemon.appdaemon import AppDaemon
+
+if TYPE_CHECKING:
+    from appdaemon.appdaemon import AppDaemon
 
 
 class Threading:
-    def __init__(self, ad: AppDaemon, kwargs):
+    """Subsystem container for managing :class:`~threading.Thread` objects"""
+
+    AD: "AppDaemon"
+    """Reference to the AppDaemon container object
+    """
+    logger: Logger
+    """Standard python logger named ``AppDaemon._threading``
+    """
+    diag: Logger
+    """Standard python logger named ``Diag``
+    """
+    thread_count: int
+    threads: Dict[str, Dict[str, Union[Thread, Queue]]]
+    """Dictionary with keys of the thread ID (string beginning with `thread-`) and values of another dictionary with `thread` and `queue` keys that have values of :class:`~threading.Thread` and :class:`~queue.Queue` objects respectively."""
+    auto_pin: bool
+    pin_threads: int
+    total_threads: int
+    pin_apps: Optional[bool]
+    next_thread: Optional[int]
+    last_stats_time: datetime.datetime
+    callback_list: List[Dict]
+
+    def __init__(self, ad: "AppDaemon", kwargs):
         self.AD = ad
         self.kwargs = kwargs
 
@@ -49,11 +76,17 @@ class Threading:
         self.callback_list = []
 
     async def get_q_update(self):
+        """Updates queue sizes"""
         for thread in self.threads:
             qsize = self.get_q(thread).qsize()
             await self.set_state("_threading", "admin", "thread.{}".format(thread), q=qsize)
 
     async def get_callback_update(self):
+        """Updates the sensors with information about how many callbacks have been fired. Called by the :class:`~appdaemon.admin_loop.AdminLoop`
+
+        - ``sensor.callbacks_average_fired``
+        - ``sensor.callbacks_average_executed``
+        """
         now = datetime.datetime.now()
         self.callback_list.append(
             {"fired": self.current_callbacks_fired, "executed": self.current_callbacks_executed, "ts": now}
@@ -170,7 +203,7 @@ class Threading:
             },
         )
 
-    def get_q(self, thread_id):
+    def get_q(self, thread_id: str) -> Queue:
         return self.threads[thread_id]["queue"]
 
     @staticmethod

--- a/appdaemon/utility_loop.py
+++ b/appdaemon/utility_loop.py
@@ -3,10 +3,14 @@
 import asyncio
 import datetime
 import traceback
+from logging import Logger
+from typing import TYPE_CHECKING
 
 import appdaemon.utils as utils
 from appdaemon.app_management import UpdateMode
-from appdaemon.appdaemon import AppDaemon
+
+if TYPE_CHECKING:
+    from appdaemon.appdaemon import AppDaemon
 
 
 class Utility:
@@ -15,10 +19,14 @@ class Utility:
     Checks for file changes, overdue threads, thread starvation, and schedules regular state refreshes.
     """
 
-    AD: AppDaemon
-    stopping: bool
+    AD: "AppDaemon"
+    """Reference to the AppDaemon container object
+    """
 
-    def __init__(self, ad: AppDaemon):
+    stopping: bool
+    logger: Logger
+
+    def __init__(self, ad: "AppDaemon"):
         """Constructor.
 
         Args:
@@ -29,6 +37,7 @@ class Utility:
         self.stopping = False
         self.logger = ad.logging.get_child("_utility")
         self.booted = None
+        # self.AD.loop.create_task(self.loop())
 
     def stop(self):
         """Called by the AppDaemon object to terminate the loop cleanly

--- a/docs/INTERNALS.rst
+++ b/docs/INTERNALS.rst
@@ -40,16 +40,30 @@ events
 .. automodule:: appdaemon.events
    :members:
 
+futures
+=======
+.. automodule:: appdaemon.futures
+   :members:
+
+http
+======
+.. automodule:: appdaemon.http
+   :members:
+
 logging
 =======
 .. automodule:: appdaemon.logging
    :members:
 
+main
+====
+
 .. automodule:: appdaemon.__main__
    :members:
 
-main
-====
+plugins
+=======
+
 .. automodule:: appdaemon.plugin_management
    :members:
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,8 +6,8 @@
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
-import sys
 import os
+import sys
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the


### PR DESCRIPTION
- Resolved the issue with circular imports, so the type hints are read properly by your IDE.
- Added lots of type hints
- Added docstrings
- Sorted imports of some files with `isort`
- Tracked python files now with absolute paths
- `app_dir` and `config_dif` are both now resolved into absolute paths, which allows AppDaemon to be run with a relative path