### PR TITLE
Update pirateweather.yaml

### DIFF
--- a/appdaemon/widgets/pirateweather.yaml
+++ b/appdaemon/widgets/pirateweather.yaml
@@ -60,4 +60,5 @@ icons:
   rain: mdi-umbrella
   sleet: mdi-weather-snowy-rainy
   unknown: mdi-umbrella
+  none: mdi-umbrella
 static_icons: []


### PR DESCRIPTION
PirateWeather now returns "none" when there is no precipitation, so an icon definition is added for none. Previously "unknown" was returned.