### PR TITLE
Annotate delay in ADAPI.sleep as float

### DIFF
--- a/appdaemon/adapi.py
+++ b/appdaemon/adapi.py
@@ -3194,7 +3194,7 @@ class ADAPI:
         return f
 
     @staticmethod
-    async def sleep(delay: int, result=None) -> None:
+    async def sleep(delay: float, result=None) -> None:
         """Pause execution for a certain time span
         (not available in sync apps)
 


### PR DESCRIPTION
The `delay` argument is passed directly to `asyncio.sleep`, which accepts a float, and the docstring of `ADAPI.sleep` already states that `delay` is a float. Integers are readily accepted as arguments where floats are expected by all major typecheckers, so the change is safe from that perspective.