### PR TITLE
Fix type hint

### DIFF
--- a/appdaemon/adapi.py
+++ b/appdaemon/adapi.py
@@ -2162,7 +2162,7 @@ class ADAPI:
         return now.astimezone(self.AD.tz)
 
     @utils.sync_wrapper
-    async def get_now_ts(self) -> int:
+    async def get_now_ts(self) -> float:
         """Returns the current Local Timestamp.
 
         Examples:


### PR DESCRIPTION
datetime.datetime.utcnow().timestamp() returns a float.  The given example already shows this correct.