### PR TITLE
Improve sync_wrapper's definition so that we get better typing

### DIFF
--- a/appdaemon/entity.py
+++ b/appdaemon/entity.py
@@ -103,7 +103,7 @@ class Entity:
 
     @utils.sync_wrapper
     async def get_state(
-        self, attribute: str = None, default: Any = None, copy: bool = True, **kwargs: Optional[Any]
+        self, attribute: str | None = None, default: Any = None, copy: bool = True, **kwargs: Optional[Any]
     ) -> Any:
         """Gets the state of any entity within AD.
 
@@ -280,7 +280,7 @@ class Entity:
         return await self.AD.state.add_state_callback(name, namespace, entity_id, callback, kwargs)
 
     @utils.sync_wrapper
-    async def add(self, state: Union[str, int, float] = None, attributes: dict = None) -> None:
+    async def add(self, state: Union[str, int, float] | None = None, attributes: dict | None = None) -> None:
         """Adds a non-existent entity, by creating it within a namespaces.
 
         It should be noted that this api call, is mainly for creating AD internal entities.
@@ -369,9 +369,9 @@ class Entity:
     async def wait_state(
         self,
         state: Any,
-        attribute: Union[str, int] = None,
+        attribute: Union[str, int] | None = None,
         duration: Union[int, float] = 0,
-        timeout: Union[int, float] = None,
+        timeout: Union[int, float] | None = None,
     ) -> None:
         """Used to wait for the state of an entity's attribute
 

--- a/appdaemon/utils.py
+++ b/appdaemon/utils.py
@@ -215,7 +215,7 @@ def check_state(logger, new_state, callback_state, name) -> bool:
     return passed
 
 T = ParamSpec('T') # Arguments to the function
-def sync_wrapper(coro: Callable[T]) -> Callable[T]:
+def sync_wrapper(coro: Callable[T, Any]) -> Callable[T, Any]:
     @wraps(coro)
     def inner_sync_wrapper(self, *args, **kwargs):
         is_async = None

--- a/appdaemon/utils.py
+++ b/appdaemon/utils.py
@@ -20,7 +20,7 @@ from collections.abc import Iterable
 from datetime import timedelta
 from functools import wraps
 from types import ModuleType
-from typing import Any, Callable, Dict, ParamSpec, TypeVar, Awaitable, Union
+from typing import Any, Callable, Dict, ParamSpec
 
 import dateutil.parser
 import tomli

--- a/appdaemon/utils.py
+++ b/appdaemon/utils.py
@@ -215,8 +215,7 @@ def check_state(logger, new_state, callback_state, name) -> bool:
     return passed
 
 T = ParamSpec('T') # Arguments to the function
-R = TypeVar('R') # Return type of the function
-def sync_wrapper(coro: Callable[T, Awaitable[R]]) -> Callable[T, Union[R, Awaitable[R]]]:
+def sync_wrapper(coro: Callable[T]) -> Callable[T]:
     @wraps(coro)
     def inner_sync_wrapper(self, *args, **kwargs):
         is_async = None
@@ -237,7 +236,7 @@ def sync_wrapper(coro: Callable[T, Awaitable[R]]) -> Callable[T, Union[R, Awaita
 
         return f
 
-    return inner_sync_wrapper  # type: ignore
+    return inner_sync_wrapper
 
 
 def _timeit(func):

--- a/appdaemon/utils.py
+++ b/appdaemon/utils.py
@@ -20,7 +20,7 @@ from collections.abc import Iterable
 from datetime import timedelta
 from functools import wraps
 from types import ModuleType
-from typing import Any, Callable, Dict
+from typing import Any, Callable, Dict, ParamSpec, TypeVar, Awaitable, Union
 
 import dateutil.parser
 import tomli
@@ -214,8 +214,9 @@ def check_state(logger, new_state, callback_state, name) -> bool:
 
     return passed
 
-
-def sync_wrapper(coro) -> Callable:
+T = ParamSpec('T') # Arguments to the function
+R = TypeVar('R') # Return type of the function
+def sync_wrapper(coro: Callable[T, Awaitable[R]]) -> Callable[T, Union[R, Awaitable[R]]]:
     @wraps(coro)
     def inner_sync_wrapper(self, *args, **kwargs):
         is_async = None
@@ -229,14 +230,14 @@ def sync_wrapper(coro) -> Callable:
 
         if is_async is True:
             # don't use create_task. It's python3.7 only
-            f = asyncio.ensure_future(coro(self, *args, **kwargs))
+            f = asyncio.ensure_future(coro(self, *args, **kwargs)) # type: ignore
             self.AD.futures.add_future(self.name, f)
         else:
-            f = run_coroutine_threadsafe(self, coro(self, *args, **kwargs))
+            f = run_coroutine_threadsafe(self, coro(self, *args, **kwargs)) # type: ignore
 
         return f
 
-    return inner_sync_wrapper
+    return inner_sync_wrapper  # type: ignore
 
 
 def _timeit(func):


### PR DESCRIPTION
Before, calling functions such as `self.get_state` or `self.turn_on` with anything else but the required type (in these two cases, str) would not lead to a type error, but rather to a runtime error long down the chain.

This now properly fails to typecheck.

```
Argument of type "whatever" cannot be assigned to parameter "entity_id" of type "str"
```