### PR TITLE
removed relative imports for legacy compatibility

### DIFF
--- a/appdaemon/adapi.py
+++ b/appdaemon/adapi.py
@@ -16,11 +16,10 @@ from collections.abc import Callable
 import iso8601
 
 from appdaemon import utils
+from appdaemon import exceptions as ade
 from appdaemon.appdaemon import AppDaemon
 from appdaemon.entity import Entity
 from appdaemon.logging import Logging
-
-from . import exceptions as ade
 
 if TYPE_CHECKING:
     from .models.config.app import AppConfig

--- a/appdaemon/adbase.py
+++ b/appdaemon/adbase.py
@@ -4,7 +4,7 @@ from logging import Logger
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from . import adapi
+from appdaemon import adapi
 
 if TYPE_CHECKING:
     from .appdaemon import AppDaemon

--- a/appdaemon/plugins/hass/hassapi.py
+++ b/appdaemon/plugins/hass/hassapi.py
@@ -5,16 +5,16 @@ from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Any, Callable, Literal, Type, overload
 
-from ... import exceptions as ade
-from ... import utils
-from ...adapi import ADAPI
-from ...adbase import ADBase
-from ...appdaemon import AppDaemon
-from ...models.notification.android import AndroidData
-from ...models.notification.base import NotificationData
-from ...models.notification.iOS import iOSData
-from .hassplugin import HassPlugin
-from .notifications import AndroidNotification
+from appdaemon import exceptions as ade
+from appdaemon import utils
+from appdaemon.adapi import ADAPI
+from appdaemon.adbase import ADBase
+from appdaemon.appdaemon import AppDaemon
+from appdaemon.models.notification.android import AndroidData
+from appdaemon.models.notification.base import NotificationData
+from appdaemon.models.notification.iOS import iOSData
+from appdaemon.plugins.hass.hassplugin import HassPlugin
+from appdaemon.plugins.hass.notifications import AndroidNotification
 
 
 if TYPE_CHECKING:

--- a/appdaemon/plugins/mqtt/mqttapi.py
+++ b/appdaemon/plugins/mqtt/mqttapi.py
@@ -4,7 +4,7 @@ import appdaemon.adapi as adapi
 import appdaemon.adbase as adbase
 import appdaemon.utils as utils
 
-from ...appdaemon import AppDaemon
+from appdaemon.appdaemon import AppDaemon
 
 if TYPE_CHECKING:
     from ...models.config import AppConfig


### PR DESCRIPTION
This fix is to make the old import method still work. The docs previously directed users to declare apps using imports like this:

```python
import hassapi as hass

class HelloWorld(hass.Hass):
    def initialize(self):
       self.log("Hello from AppDaemon")
```

This is now the preferred method:
```python
from appdaemon.plugins import hass

class HelloWorld(hass.Hass):
    def initialize(self):
       self.log("Hello from AppDaemon")
```