### PR TITLE
legacy import fixes

### DIFF
--- a/appdaemon/adapi.py
+++ b/appdaemon/adapi.py
@@ -21,6 +21,20 @@ from appdaemon.appdaemon import AppDaemon
 from appdaemon.entity import Entity
 from appdaemon.logging import Logging
 
+
+# Check if the module is being imported using the legacy method
+if __name__ == Path(__file__).name:
+    from appdaemon.logging import Logging
+
+    # It's possible to instantiate the Logging system again here because it's a singleton, and it will already have been
+    # created at this point if the legacy import method is being used by an app. Using this accounts for the user maybe
+    # having configured the error logger to use a different name than 'Error'
+    Logging().get_error().warning(
+        "Importing 'adapi' directly is deprecated and will be removed in a future version. "
+        "To use the ADAPI use 'from appdaemon import adapi' instead.",
+    )
+
+
 if TYPE_CHECKING:
     from .models.config.app import AppConfig
     from .plugin_management import PluginBase

--- a/appdaemon/adbase.py
+++ b/appdaemon/adbase.py
@@ -8,6 +8,20 @@ from appdaemon import adapi
 
 from .utils import StateAttrs
 
+
+# Check if the module is being imported using the legacy method
+if __name__ == Path(__file__).name:
+    from appdaemon.logging import Logging
+
+    # It's possible to instantiate the Logging system again here because it's a singleton, and it will already have been
+    # created at this point if the legacy import method is being used by an app. Using this accounts for the user maybe
+    # having configured the error logger to use a different name than 'Error'
+    Logging().get_error().warning(
+        "Importing 'adbase' directly is deprecated and will be removed in a future version. "
+        "To use the ADBase use 'from appdaemon import adbase' instead.",
+    )
+
+
 if TYPE_CHECKING:
     from .appdaemon import AppDaemon
     from .logging import Logging

--- a/appdaemon/plugins/hass/hassapi.py
+++ b/appdaemon/plugins/hass/hassapi.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 import re
 from ast import literal_eval
 from collections.abc import Iterable
@@ -18,7 +19,7 @@ from appdaemon.plugins.hass.notifications import AndroidNotification
 
 
 # Check if the module is being imported using the legacy method
-if __name__ == "hassapi":
+if __name__ == Path(__file__).name:
     from appdaemon.logging import Logging
 
     # It's possible to instantiate the Logging system again here because it's a singleton, and it will already have been

--- a/appdaemon/plugins/mqtt/mqttapi.py
+++ b/appdaemon/plugins/mqtt/mqttapi.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Optional, Union
 
 import appdaemon.adapi as adapi
@@ -12,7 +13,7 @@ if TYPE_CHECKING:
 
 
 # Check if the module is being imported using the legacy method
-if __name__ == "mqttapi":
+if __name__ == Path(__file__).name:
     from appdaemon.logging import Logging
 
     # It's possible to instantiate the Logging system again here because it's a singleton, and it will already have been


### PR DESCRIPTION
Applies legacy import fixes to `adapi` and `adbase`. Both of the following now work:

```python
import adbase as ad
import adapi as ad
```