### PR TITLE
Kwarg parsing

### DIFF
--- a/appdaemon/threads.py
+++ b/appdaemon/threads.py
@@ -1049,7 +1049,12 @@ class Threading:
                     if use_dictionary_unpacking:
                         funcref = functools.partial(funcref, *pos_args, **kwargs)
                     else:
-                        funcref = functools.partial(funcref, *pos_args, kwargs)
+                        if isinstance(funcref, functools.partial):
+                            pos_args += funcref.args
+                            kwargs.update(funcref.keywords)
+                            funcref = functools.partial(funcref.func, kwargs)
+                        else:
+                            funcref = functools.partial(funcref, *pos_args, kwargs)
 
                     callback = f'{funcref.func.__qualname__} for {name}'
                     update_coro = self.update_thread_info(thread_id, callback, name, _type, _id, silent)

--- a/appdaemon/threads.py
+++ b/appdaemon/threads.py
@@ -962,7 +962,12 @@ class Threading:
                 if use_dictionary_unpacking:
                     funcref = functools.partial(funcref, *pos_args, **kwargs)
                 else:
-                    funcref = functools.partial(funcref, *pos_args, kwargs)
+                    if isinstance(funcref, functools.partial):
+                        pos_args += funcref.args
+                        kwargs.update(funcref.keywords)
+                        funcref = functools.partial(funcref.func, kwargs)
+                    else:
+                        funcref = functools.partial(funcref, *pos_args, kwargs)
 
                 callback = f'{funcref.func.__name__}() in {name}'
                 await self.update_thread_info("async", callback, name, _type, _id, silent)
@@ -975,7 +980,7 @@ class Threading:
                         await funcref()
                     except Exception as exc:
                         # positional arguments common to all the AppCallbackFail exceptions
-                        pos_args = (name, funcref.args, funcref.keywords)
+                        pos_args = (name, funcref)
                         match args['type']:
                             case "event":
                                 raise ade.EventCallbackFail(*pos_args, args["event"]) from exc


### PR DESCRIPTION
`kwargs` now properly passed for functions that don't use dictionary unpacking. Resolves #2218 

```python
from appdaemon.plugins import hass

class Scratch(hass.Hass):
    def initialize(self):
       self.log("Hello from AppDaemon")
       self.listen_state(self.state_callback, "input_boolean.test_toggle", my_kwarg=123)
       self.listen_state(self.state_callback2, "input_boolean.test_toggle", my_kwarg=456)

       self.run_every(self.scheduled_callback, 'now', 2, my_kwarg=123)
       self.run_every(self.scheduled_callback2, 'now', 2, my_kwarg=456)

    def state_callback(self, entity, attribute, old, new, kwargs):
        self.log(f"State changed: {entity} {attribute} {kwargs}")

    def state_callback2(self, entity, attribute, old, new, **kwargs):
        self.log(f"State changed 2: {entity} {attribute} {kwargs}")

    def scheduled_callback(self, kwargs):
        self.log(f'Scheduled callback triggered: {kwargs}')

    def scheduled_callback2(self, **kwargs):
        self.log(f'Scheduled callback triggered 2: {kwargs}')
```

```
2025-04-17 18:11:17.264448 INFO scratch: Scheduled callback triggered: {'__thread_id': 'thread-0', 'my_kwarg': 123}
2025-04-17 18:11:17.267081 INFO scratch: Scheduled callback triggered 2: {'my_kwarg': 456, '__thread_id': 'thread-0'}
2025-04-17 18:11:19.263556 INFO scratch: Scheduled callback triggered: {'__thread_id': 'thread-0', 'my_kwarg': 123}
2025-04-17 18:11:19.264904 INFO scratch: Scheduled callback triggered 2: {'my_kwarg': 456, '__thread_id': 'thread-0'}
2025-04-17 18:11:20.426431 INFO scratch: State changed: input_boolean.test_toggle state {'my_kwarg': 123, '__thread_id': 'thread-0'}
2025-04-17 18:11:20.427750 INFO scratch: State changed 2: input_boolean.test_toggle state {'my_kwarg': 456, '__thread_id': 'thread-0'}
2025-04-17 18:11:21.262565 INFO scratch: Scheduled callback triggered: {'__thread_id': 'thread-0', 'my_kwarg': 123}
2025-04-17 18:11:21.263804 INFO scratch: Scheduled callback triggered 2: {'my_kwarg': 456, '__thread_id': 'thread-0'}
2025-04-17 18:11:22.357021 INFO scratch: State changed: input_boolean.test_toggle state {'my_kwarg': 123, '__thread_id': 'thread-0'}
2025-04-17 18:11:22.358500 INFO scratch: State changed 2: input_boolean.test_toggle state {'my_kwarg': 456, '__thread_id': 'thread-0'}
2025-04-17 18:11:23.262549 INFO scratch: Scheduled callback triggered: {'__thread_id': 'thread-0', 'my_kwarg': 123}
2025-04-17 18:11:23.264011 INFO scratch: Scheduled callback triggered 2: {'my_kwarg': 456, '__thread_id': 'thread-0'}
2025-04-17 18:11:25.262501 INFO scratch: Scheduled callback triggered: {'__thread_id': 'thread-0', 'my_kwarg': 123}
2025-04-17 18:11:25.263971 INFO scratch: Scheduled callback triggered 2: {'my_kwarg': 456, '__thread_id': 'thread-0'}
2025-04-17 18:11:27.262631 INFO scratch: Scheduled callback triggered: {'__thread_id': 'thread-0', 'my_kwarg': 123}
2025-04-17 18:11:27.264103 INFO scratch: Scheduled callback triggered 2: {'my_kwarg': 456, '__thread_id': 'thread-0'}
```


```python
from appdaemon.plugins import hass

class Scratch(hass.Hass):
    def initialize(self):
       self.log("Hello from AppDaemon")
       self.listen_state(self.state_callback, "input_boolean.test_toggle", my_kwarg=123)
       self.listen_state(self.state_callback2, "input_boolean.test_toggle", my_kwarg=456)

       self.run_every(self.scheduled_callback, 'now', 2, my_kwarg=123)
       self.run_every(self.scheduled_callback2, 'now', 2, my_kwarg=456)

    async def state_callback(self, entity, attribute, old, new, kwargs):
        self.log(f"State changed: {entity} {attribute} {kwargs}")

    async def state_callback2(self, entity, attribute, old, new, **kwargs):
        self.log(f"State changed 2: {entity} {attribute} {kwargs}")

    async def scheduled_callback(self, kwargs):
        self.log(f'Scheduled callback triggered: {kwargs}')

    async def scheduled_callback2(self, **kwargs):
        self.log(f'Scheduled callback triggered 2: {kwargs}')
```

```
2025-04-17 18:12:58.686612 INFO scratch: Scheduled callback triggered: {'__thread_id': 'MainThread', 'my_kwarg': 123}
2025-04-17 18:12:58.690069 INFO scratch: Scheduled callback triggered 2: {'my_kwarg': 456, '__thread_id': 'MainThread'}
2025-04-17 18:13:00.687009 INFO scratch: Scheduled callback triggered: {'__thread_id': 'MainThread', 'my_kwarg': 123}
2025-04-17 18:13:00.689136 INFO scratch: Scheduled callback triggered 2: {'my_kwarg': 456, '__thread_id': 'MainThread'}
2025-04-17 18:13:02.687507 INFO scratch: Scheduled callback triggered: {'__thread_id': 'MainThread', 'my_kwarg': 123}
2025-04-17 18:13:02.689631 INFO scratch: Scheduled callback triggered 2: {'my_kwarg': 456, '__thread_id': 'MainThread'}
2025-04-17 18:13:03.449319 INFO scratch: State changed: input_boolean.test_toggle state {'my_kwarg': 123, '__thread_id': 'MainThread'}
2025-04-17 18:13:03.451157 INFO scratch: State changed 2: input_boolean.test_toggle state {'my_kwarg': 456, '__thread_id': 'MainThread'}
2025-04-17 18:13:04.688446 INFO scratch: Scheduled callback triggered: {'__thread_id': 'MainThread', 'my_kwarg': 123}
2025-04-17 18:13:04.690599 INFO scratch: Scheduled callback triggered 2: {'my_kwarg': 456, '__thread_id': 'MainThread'}
2025-04-17 18:13:05.847839 INFO scratch: State changed: input_boolean.test_toggle state {'my_kwarg': 123, '__thread_id': 'MainThread'}
2025-04-17 18:13:05.849715 INFO scratch: State changed 2: input_boolean.test_toggle state {'my_kwarg': 456, '__thread_id': 'MainThread'}
2025-04-17 18:13:06.688177 INFO scratch: Scheduled callback triggered: {'__thread_id': 'MainThread', 'my_kwarg': 123}
2025-04-17 18:13:06.690268 INFO scratch: Scheduled callback triggered 2: {'my_kwarg': 456, '__thread_id': 'MainThread'}
2025-04-17 18:13:08.687066 INFO scratch: Scheduled callback triggered: {'__thread_id': 'MainThread', 'my_kwarg': 123}
2025-04-17 18:13:08.689179 INFO scratch: Scheduled callback triggered 2: {'my_kwarg': 456, '__thread_id': 'MainThread'}
2025-04-17 18:13:10.687339 INFO scratch: Scheduled callback triggered: {'__thread_id': 'MainThread', 'my_kwarg': 123}
2025-04-17 18:13:10.689478 INFO scratch: Scheduled callback triggered 2: {'my_kwarg': 456, '__thread_id': 'MainThread'}
```

