### PR TITLE
fixed namespace default behaviors

### DIFF
--- a/appdaemon/models/config/misc.py
+++ b/appdaemon/models/config/misc.py
@@ -40,7 +40,7 @@ class NamespaceConfig(BaseModel):
         if values.get("writeback") is not None:
             values["persistent"] = True
         return values
-    
+
     @model_validator(mode="after")
     def validate_writeback(self):
         """Makes the writeback safe by default if persist is set to True."""


### PR DESCRIPTION
Fixed some default behavior, specifically making namespaces persistent if a writeback is specified. Should resolve #2219 