### PR TITLE
Fixed Home Assistant plugin startup

### DIFF
--- a/appdaemon/models/config/plugin.py
+++ b/appdaemon/models/config/plugin.py
@@ -87,6 +87,8 @@ class HASSConfig(PluginConfig):
     ha_key: Annotated[SecretStr, deprecated("'ha_key' is deprecated. Please use long lived tokens instead")] | None = None
     appdaemon_startup_conditions: StartupConditions | None = None
     plugin_startup_conditions: StartupConditions | None = None
+    enable_started_event: bool = True
+    """If true, the plugin will wait for the 'homeassistant_started' event before starting the plugin."""
     cert_path: CoercedPath | None = None
     cert_verify: bool | None = None
     commtype: str = "WS"

--- a/appdaemon/plugins/hass/hassplugin.py
+++ b/appdaemon/plugins/hass/hassplugin.py
@@ -204,9 +204,13 @@ class HassPlugin(PluginBase):
         if conditions is not None:
             self.logger.info("All plugin startup conditions met")
 
-        self.logger.info('Waiting for Home Assistant to start')
-        await self.ready_event.wait()
-        # self.ready_event.set()
+        if not self.config.enable_started_event and not self.is_ready:
+            # check the metadata to see if it's already running
+            await self.get_hass_config() # this will set the ready event if it is
+        
+        if not self.is_ready:
+            self.logger.info("Waiting for Home Assistant to start")
+            await self.ready_event.wait()
 
         await self.notify_plugin_started(
             await self.get_hass_config(),

--- a/appdaemon/plugins/hass/hassplugin.py
+++ b/appdaemon/plugins/hass/hassplugin.py
@@ -207,7 +207,7 @@ class HassPlugin(PluginBase):
         if not self.config.enable_started_event and not self.is_ready:
             # check the metadata to see if it's already running
             await self.get_hass_config() # this will set the ready event if it is
-        
+
         if not self.is_ready:
             self.logger.info("Waiting for Home Assistant to start")
             await self.ready_event.wait()


### PR DESCRIPTION
Re-implemented the old behavior for the `Hass` plugin starting up

Should resolve #2226