### PR TITLE
Services cleanup

### DIFF
--- a/appdaemon/adapi.py
+++ b/appdaemon/adapi.py
@@ -1824,6 +1824,18 @@ class ADAPI:
         self.logger.debug("list_services: %s", namespace)
         return self.AD.services.list_services(namespace)  # retrieve services
 
+    @overload # This overload provides the type hints for the Hass-specific version of this method
+    async def call_service(
+        self,
+        service: str,
+        namespace: str | None = None,
+        timeout: str | int | float | None = None,
+        callback: Callable | None = None,
+        hass_timeout: str | int | float | None = None,
+        suppress_log_messages: bool = False,
+        **data,
+    ) -> Any: ...
+
     @utils.sync_decorator
     async def call_service(
         self,

--- a/appdaemon/adapi.py
+++ b/appdaemon/adapi.py
@@ -1802,27 +1802,27 @@ class ADAPI:
         return self.AD.services.deregister_service(namespace, *service.split("/"), __name=self.name)
 
     def list_services(self, namespace: str = "global") -> list[dict[str, str]]:
-        """List all services available within AD
-
-        Using this function, an App can request all available services within AD
+        """List all services available within AppDaemon
 
         Args:
-            namespace(str, optional): If a `namespace` is provided, AppDaemon will request
-                the services within the given namespace. On the other hand, if no namespace is given,
-                AppDaemon will use the last specified namespace or the default namespace.
-                To get all services across AD, pass `global`. See the section on `namespaces <APPGUIDE.html#namespaces>`__
-                for a detailed description. In most cases, it is safe to ignore this parameter.
+            namespace(str, optional): If a ``namespace`` is provided, this function will return services only in that
+                namespace. If no namespace is given, AppDaemon will use the app's current namespace, which will be the
+                default namespace unless changed with ``self.set_namespace``. The default value for ``namespace`` is
+                ``global``, which will return services across all namespaces. See the section on
+                `namespaces <APPGUIDE.html#namespaces>`__ for more information.
 
         Returns:
             List of dictionary with keys ``namespace``, ``domain``, and ``service``.
 
         Examples:
-            >>> self.list_services(namespace="global")
+            >>> services = self.list_services()
+
+            >>> services = self.list_services("default")
 
         """
 
         self.logger.debug("list_services: %s", namespace)
-        return self.AD.services.list_services(namespace)  # retrieve services
+        return self.AD.services.list_services(namespace)
 
     @overload # This overload provides the type hints for the Hass-specific version of this method
     async def call_service(
@@ -1868,11 +1868,11 @@ class ADAPI:
             timeout (str | int | float, optional): The internal AppDaemon timeout for the service call. If no value is
                 specified, the default timeout is 60s. The default value can be changed using the
                 ``appdaemon.internal_function_timeout`` config setting.
-            callback (callable): The non-async callback to be executed when complete. It should accept a single argument, which
-                will be the result of the service call. This is the recommended method for calling services which might
-                take a long time to complete. This effectively bypasses the ``timeout`` argument because it only applies
-                to this function, which will return immediately instead of waiting for the result if a `callback` is
-                specified.
+            callback (callable): The non-async callback to be executed when complete. It should accept a single
+                argument, which will be the result of the service call. This is the recommended method for calling
+                services which might take a long time to complete. This effectively bypasses the ``timeout`` argument
+                because it only applies to this function, which will return immediately instead of waiting for the
+                result if a `callback` is specified.
             hass_timeout (str | int | float, optional): Only applicable to the Hass plugin. Sets the amount of time to
                 wait for a response from Home Assistant. If no value is specified, the default timeout is 10s. The
                 default value can be changed using the ``ws_timeout`` setting the in the Hass plugin configuration in
@@ -1897,6 +1897,7 @@ class ADAPI:
 
         Examples:
             HASS
+            ^^^^
 
             >>> self.call_service("light/turn_on", entity_id="light.office_lamp", color_name="red")
             >>> self.call_service("notify/notify", title="Hello", message="Hello World")
@@ -1908,11 +1909,13 @@ class ADAPI:
                 )["result]["response"]["calendar.home"]["events"]
 
             MQTT
+            ^^^^
 
             >>> self.call_service("mqtt/subscribe", topic="homeassistant/living_room/light", qos=2)
             >>> self.call_service("mqtt/publish", topic="homeassistant/living_room/light", payload="on")
 
             Utility
+            ^^^^^^^
 
             It's important that the ``namespace`` arg is set to ``admin`` for these services, as they do not exist
             within the default namespace, and apps cannot exist in the ``admin`` namespace. If the namespace is not

--- a/appdaemon/adapi.py
+++ b/appdaemon/adapi.py
@@ -1824,19 +1824,6 @@ class ADAPI:
         self.logger.debug("list_services: %s", namespace)
         return self.AD.services.list_services(namespace)  # retrieve services
 
-    @overload
-    async def call_service(
-        self,
-        service: str,
-        namespace: str | None = None,
-        timeout: int | float | None = None,
-        return_result: bool = True,
-        callback: Callable | None = None,
-        hass_timeout: float = 10,
-        suppress_log_messages: bool = False,
-        **data,
-    ) -> Any: ...
-
     @utils.sync_decorator
     async def call_service(
         self,

--- a/appdaemon/adapi.py
+++ b/appdaemon/adapi.py
@@ -1806,10 +1806,9 @@ class ADAPI:
 
         Args:
             namespace(str, optional): If a ``namespace`` is provided, this function will return services only in that
-                namespace. If no namespace is given, AppDaemon will use the app's current namespace, which will be the
-                default namespace unless changed with ``self.set_namespace``. The default value for ``namespace`` is
-                ``global``, which will return services across all namespaces. See the section on
-                `namespaces <APPGUIDE.html#namespaces>`__ for more information.
+                namespace. Otherwise, the default value for ``namespace`` is ``global``, which will return services
+                across all namespaces. See the section on `namespaces <APPGUIDE.html#namespaces>`__ for more
+                information.
 
         Returns:
             List of dictionary with keys ``namespace``, ``domain``, and ``service``.
@@ -1818,6 +1817,8 @@ class ADAPI:
             >>> services = self.list_services()
 
             >>> services = self.list_services("default")
+
+            >>> services = self.list_services("mqtt")
 
         """
 

--- a/appdaemon/adapi.py
+++ b/appdaemon/adapi.py
@@ -1883,6 +1883,9 @@ class ADAPI:
                 Appdaemon will suppress logging of warnings for service calls to Home Assistant, specifically timeouts
                 and non OK statuses. Use this flag and set it to ``True`` to supress these log messages if you are
                 performing your own error checking as described `here <APPGUIDE.html#some-notes-on-service-calls>`__
+            service_data (dict, optional): Used as an additional dictionary to pass arguments into the ``service_data``
+                field of the JSON that goes to Home Assistant. This is useful if you have a dictionary that you want to
+                pass in that has a key like ``target`` which is otherwise used for the ``target`` argument.
             **data: Any other keyword arguments get passed to the service call as ``service_data``. Each service takes
                 different parameters, so this will vary from service to service. For example, most services require
                 ``entity_id``. The parameters for each service can be found in the actions tab of developer tools in

--- a/appdaemon/appdaemon.py
+++ b/appdaemon/appdaemon.py
@@ -229,10 +229,6 @@ class AppDaemon(metaclass=Singleton):
         return self.config.import_paths
 
     @property
-    def internal_function_timeout(self):
-        return self.config.internal_function_timeout
-
-    @property
     def invalid_config_warnings(self):
         return self.config.invalid_config_warnings
 

--- a/appdaemon/entity.py
+++ b/appdaemon/entity.py
@@ -358,7 +358,12 @@ class Entity:
         namespace = namespace or self.namespace
         kwargs["entity_id"] = self.entity_id
         self.logger.debug("call_service: %s/%s, %s", self.domain, service, kwargs)
-        return await self.AD.services.call_service(namespace, self.domain, service, self.name, kwargs)
+        return await self.AD.services.call_service(
+            namespace=namespace,
+            domain=self.domain,
+            service=service,
+            data=kwargs
+        )  # fmt: skip
 
     async def wait_state(
         self,

--- a/appdaemon/exceptions.py
+++ b/appdaemon/exceptions.py
@@ -44,7 +44,7 @@ def exception_handler(appdaemon: "AppDaemon", loop: asyncio.AbstractEventLoop, c
     """Handler to attach to the main event loop as a backstop for any async exception"""
     user_exception_block(
         logging.getLogger('Error'),
-        context['exception'],
+        context.get('exception'),
         appdaemon.app_dir,
         header='Unhandled exception in event loop'
     )

--- a/appdaemon/http.py
+++ b/appdaemon/http.py
@@ -691,7 +691,12 @@ class HTTP:
 
             self.logger.debug("call_service() args = %s", args)
 
-            res = await self.AD.services.call_service(namespace, domain, service, args)
+            res = await self.AD.services.call_service(
+                namespace=namespace,
+                domain=domain,
+                service=service,
+                data=args
+            )  # fmt: skip
             return web.json_response({"response": res}, status=200, dumps=utils.convert_json)
 
         except Exception:

--- a/appdaemon/models/config/appdaemon.py
+++ b/appdaemon/models/config/appdaemon.py
@@ -9,12 +9,12 @@ from pydantic import BaseModel, BeforeValidator, ConfigDict, Discriminator, Fiel
 from pytz.tzinfo import BaseTzInfo
 from typing_extensions import deprecated
 
+from appdaemon import utils
 from appdaemon.models.config.http import CoercedPath
 
 from ...models.config.plugin import HASSConfig, MQTTConfig
 from ...version import __version__
 from .misc import FilterConfig, NamespaceConfig
-
 
 def plugin_discriminator(plugin):
     if isinstance(plugin, dict):
@@ -67,7 +67,10 @@ class AppDaemonConfig(BaseModel, extra="allow"):
     admin_delay: int = 1
     plugin_performance_update: int = 10
     """How often in seconds to update the admin entities with the plugin performance data"""
-    max_utility_skew: timedelta = Field(default_factory=lambda: timedelta(seconds=2), before_validator=lambda v: timedelta(seconds=v))
+    max_utility_skew: Annotated[
+        timedelta,
+        BeforeValidator(utils.convert_timedelta)
+    ] = Field(default_factory=lambda: timedelta(seconds=2))
     check_app_updates_profile: bool = False
     production_mode: bool = False
     invalid_config_warnings: bool = True
@@ -76,7 +79,12 @@ class AppDaemonConfig(BaseModel, extra="allow"):
     qsize_warning_threshold: int = 50
     qsize_warning_step: int = 60
     qsize_warning_iterations: int = 10
-    internal_function_timeout: int = 60
+    internal_function_timeout: Annotated[
+        timedelta,
+        BeforeValidator(utils.convert_timedelta)
+    ] = Field(default_factory=lambda: timedelta(seconds=60))
+    """Timeout for internal function calls. This determines how long apps can wait in their thread for an async function
+    to complete in the main thread."""
     use_dictionary_unpacking: Annotated[bool, deprecated("This option is no longer necessary")] = False
     uvloop: bool = False
     use_stream: bool = False

--- a/appdaemon/models/config/plugin.py
+++ b/appdaemon/models/config/plugin.py
@@ -10,6 +10,8 @@ from typing_extensions import deprecated
 
 from .common import CoercedPath
 
+from appdaemon import utils
+
 
 class PluginConfig(BaseModel, extra="allow"):
     type: str
@@ -93,7 +95,12 @@ class HASSConfig(PluginConfig):
     cert_verify: bool | None = None
     commtype: str = "WS"
     q_timeout: int = 30
-    return_result: bool | None = None
+    ws_timeout: Annotated[
+        timedelta,
+        BeforeValidator(utils.convert_timedelta)
+    ] = Field(default=timedelta(seconds=10))
+    """Default timeout for waiting for responses from the websocket connection"""
+    # return_result: bool | None = None
     suppress_log_messages: bool = False
     retry_secs: int = 5
     services_sleep_time: int = 60

--- a/appdaemon/models/config/plugin.py
+++ b/appdaemon/models/config/plugin.py
@@ -98,7 +98,7 @@ class HASSConfig(PluginConfig):
     ws_timeout: Annotated[
         timedelta,
         BeforeValidator(utils.convert_timedelta)
-    ] = Field(default=timedelta(seconds=10))
+    ] = Field(default_factory=lambda: timedelta(seconds=10))
     """Default timeout for waiting for responses from the websocket connection"""
     # return_result: bool | None = None
     suppress_log_messages: bool = False

--- a/appdaemon/models/notification/android.py
+++ b/appdaemon/models/notification/android.py
@@ -8,9 +8,11 @@ from .base import Action, Payload
 
 
 class AndroidPayload(Payload, extra="forbid"):
-    """Notification data specific to the Android Platform
+    """Data specific to the Android Platform used for configuring notifications.
 
-    https://companion.home-assistant.io/docs/notifications/notifications-basic/#android-specific
+    For more information, see the
+    `Android Specific <https://companion.home-assistant.io/docs/notifications/notifications-basic/#android-specific>`_
+    section of the Home Assistant documentation.
     """
 
     group: str | None = None
@@ -22,14 +24,37 @@ class AndroidPayload(Payload, extra="forbid"):
 
     color: str | None = None
     sticky: bool | None = None
+    """Setting sticky to ``True`` will keep the notification from being dismissed when the user selects it. Setting it
+    to ``False`` (default) will dismiss the notification upon selecting it. See
+    `Sticky Notification <https://companion.home-assistant.io/docs/notifications/notifications-basic/#sticky-notification>`_
+    for more information.
+    """
     # https://companion.home-assistant.io/docs/notifications/notifications-basic/#notification-channels
     channel: str | None = None
+    """Notification channels (on some devices: notification categories) allow you to separate your notifications easily
+    (i.e. alarm vs laundry) and customize aspects like the notification sound and a lot of other device specific
+    features. Devices running Android 8.0+ are able to create and manage notification channels on the fly using
+    automations. Once a channel is created you can navigate to your notification settings and you will find the newly
+    created channel, from there you can customize the behavior based on what your device allows.
+
+    See `Notification Channels <https://companion.home-assistant.io/docs/notifications/notifications-basic/#notification-channels>`_
+    for more information.
+    """
     importance: Literal["high", "low", "max", "min", "default"] | None = None
     priority: Literal["low", "high"] | None = None
     ttl: int | None = None
     vibration_pattern: list[int] | None = Field(default=None, alias="vibrationPattern")
     ledColor: str | None = None  # notification LED
     persistent: bool | None = None
+    """Persistent notifications are notifications that cannot be dismissed by swiping away. These are useful if you have
+    something important like an alarm being triggered. In order to use this property you must set the tag property as
+    well. The persistent property only takes boolean (``true``/``false``) values, with ``false`` being the default. The
+    persistent notification will still be dismissed once selected, to avoid this use the ``sticky`` parameter so the
+    notification stays.
+
+    See `Persistent Notification <https://companion.home-assistant.io/docs/notifications/notifications-basic/#persistent-notification>`_
+    for more information.
+    """
     timeout: int | None = None
     icon_url: str | None = None
     visibility: Literal["public", "private"] | None = None

--- a/appdaemon/plugins/hass/hassapi.py
+++ b/appdaemon/plugins/hass/hassapi.py
@@ -1009,6 +1009,18 @@ class Hass(ADBase, ADAPI):
         media_stream: Literal['music_stream', 'alarm_stream', 'alarm_stream_max'] | None = 'music_stream',
         critical: bool = False,
     ) -> dict:
+        """Convenience method for correctly creating a TTS notification for Android devices.
+
+        For more information see: `Text-to-Speech Notifications <https://companion.home-assistant.io/docs/notifications/notifications-basic#text-to-speech-notifications>`_
+
+        Args:
+            device (str): Name of the device to notify on. This gets combined with ``notify/mobile_app_<device>`` to
+            determine which notification service to call.
+            tts_text (str): String of text to translate into speech
+            media_stream (optional): Defaults to ``music_stream``.
+            critical (bool, optional): Defaults to False. If set to ``True``, the notification will use the correct
+            settings to have the TTS at the maximum possible volume. For more information see `Critical Notifications <https://companion.home-assistant.io/docs/notifications/critical-notifications/#android>`_
+        """
         return self.call_service(
             **AndroidNotification.tts(device, tts_text, media_stream, critical).to_service_call()
         )

--- a/appdaemon/plugins/hass/hassapi.py
+++ b/appdaemon/plugins/hass/hassapi.py
@@ -1015,11 +1015,11 @@ class Hass(ADBase, ADAPI):
 
         Args:
             device (str): Name of the device to notify on. This gets combined with ``notify/mobile_app_<device>`` to
-            determine which notification service to call.
+                determine which notification service to call.
             tts_text (str): String of text to translate into speech
             media_stream (optional): Defaults to ``music_stream``.
             critical (bool, optional): Defaults to False. If set to ``True``, the notification will use the correct
-            settings to have the TTS at the maximum possible volume. For more information see `Critical Notifications <https://companion.home-assistant.io/docs/notifications/critical-notifications/#android>`_
+                settings to have the TTS at the maximum possible volume. For more information see `Critical Notifications <https://companion.home-assistant.io/docs/notifications/critical-notifications/#android>`_
         """
         return self.call_service(
             **AndroidNotification.tts(device, tts_text, media_stream, critical).to_service_call()

--- a/appdaemon/plugins/hass/hassapi.py
+++ b/appdaemon/plugins/hass/hassapi.py
@@ -437,18 +437,6 @@ class Hass(ADBase, ADAPI):
     # Helper functions for services
     # Methods that use self.call_service
 
-    @overload # This overload provides the type hints for the Hass-specific version of this method
-    async def call_service(
-        self,
-        service: str,
-        namespace: str | None = None,
-        timeout: str | int | float | None = None,
-        callback: Callable | None = None,
-        hass_timeout: str | int | float | None = None,
-        suppress_log_messages: bool = False,
-        **data,
-    ) -> Any: ...
-
     # Home Assistant General
 
     @utils.sync_decorator
@@ -1147,16 +1135,14 @@ class Hass(ADBase, ADAPI):
         and ``end``. The ``start`` and ``end`` keys are converted to ``datetime`` objects.
 
         Args:
-            entity_id (str): The ID of the calendar entity to retrieve events
-                from. Defaults to "calendar.localcalendar".
+            entity_id (str): The ID of the calendar entity to retrieve events from. Defaults to
+                "calendar.localcalendar".
             days (int): The number of days to look ahead for events. Defaults to 1.
             hours (int, optional): The number of hours to look ahead for events. Defaults to None.
             minutes (int, optional): The number of minutes to look ahead for events. Defaults to None.
-            namespace(str, optional): If provided, changes the namespace for the
-                service call. Defaults to the current namespace of the app, so
-                it's safe to ignore this parameter most of the time. See the
-                section on `namespaces <APPGUIDE.html#namespaces>`__ for a detailed
-                description.
+            namespace(str, optional): If provided, changes the namespace for the service call. Defaults to the current
+                namespace of the app, so it's safe to ignore this parameter most of the time. See the section on
+                `namespaces <APPGUIDE.html#namespaces>`__ for a detailed description.
 
         Returns:
             list[dict]: A list of dicts representing the calendar events.

--- a/appdaemon/plugins/hass/hassapi.py
+++ b/appdaemon/plugins/hass/hassapi.py
@@ -437,6 +437,18 @@ class Hass(ADBase, ADAPI):
     # Helper functions for services
     # Methods that use self.call_service
 
+    @overload # This overload provides the type hints for the Hass-specific version of this method
+    async def call_service(
+        self,
+        service: str,
+        namespace: str | None = None,
+        timeout: str | int | float | None = None,
+        callback: Callable | None = None,
+        hass_timeout: str | int | float | None = None,
+        suppress_log_messages: bool = False,
+        **data,
+    ) -> Any: ...
+
     # Home Assistant General
 
     @utils.sync_decorator

--- a/appdaemon/plugins/hass/hassplugin.py
+++ b/appdaemon/plugins/hass/hassplugin.py
@@ -640,9 +640,33 @@ class HassPlugin(PluginBase):
         suppress_log_messages: bool = False,
         **data
     ):
-        """Used by ``self.check_register_service`` when calling ``self.AD.services.register_service``.
+        """Uses the websocket to call a service in Home Assistant.
 
-        This causes ``self.call_plugin_service`` to be called when a service is called in this plugin's namespace.
+        The ``self.check_register_service`` method uses this method when calling ``self.AD.services.register_service``,
+        which causes ``self.call_plugin_service`` to be called when a service is called in this plugin's namespace.
+
+        Args:
+            namespace (str): Namespace for the plugin. Used as a sanity check. Don't call this from the wrong place.
+            domain (str): Domain of the service to call
+            service (str): Name of the service to call
+            target (str | dict | None, optional): Target of the service. Defaults to None. If the ``entity_id`` argument
+                is not used, then the value of the ``target`` argument is used directly.
+            entity_id (str | list[str] | None, optional): Entity ID to target with the service call. Seems to be a
+                legacy way . Defaults to None.
+            hass_timeout (str | int | float, optional): Sets the amount of time to wait for a response from Home
+                Assistant. If no value is specified, the default timeout is 10s. The default value can be changed using
+                the ``ws_timeout`` setting the in the Hass plugin configuration in ``appdaemon.yaml``. Even if no data
+                is returned from the service call, Home Assistant will still send an acknowledgement back to AppDaemon,
+                which this timeout applies to. Note that this is separate from the ``timeout``. If ``timeout`` is
+                shorter than this one, it will trigger before this one does.
+            suppress_log_messages (bool, optional): If this is set to ``True``, Appdaemon will suppress logging of
+                warnings for service calls to Home Assistant, specifically timeouts and non OK statuses. Use this flag
+                and set it to ``True`` to supress these log messages if you are performing your own error checking as
+                described `here <APPGUIDE.html#some-notes-on-service-calls>`__
+            service_data (dict, optional): Used as an additional dictionary to pass arguments into the ``service_data``
+                field of the JSON that goes to Home Assistant. This is useful if you have a dictionary that you want to
+                pass in that has a key like ``target`` which is otherwise used for the ``target`` argument.
+            **data: Zero or more keyword arguments. These get used as the data for the service call.
         """
         # if we get a request for not our namespace something has gone very wrong
         assert namespace == self.namespace

--- a/appdaemon/plugins/hass/notifications.py
+++ b/appdaemon/plugins/hass/notifications.py
@@ -37,13 +37,19 @@ class AndroidNotification(BaseModel, extra='forbid'):
         media_stream: Literal['music_stream', 'alarm_stream', 'alarm_stream_max'] | None = 'music_stream',
         critical: bool = False,
     ) -> 'AndroidNotification':
+        """Creates a special instance of AndroidNotification for TTS notifications.
+
+        This includes setting the message to `TTS` as described in the Home Assistant documentation. See
+        https://companion.home-assistant.io/docs/notifications/notifications-basic#text-to-speech-notifications
+        for more information.
+        """
         self = cls.model_validate({
             'device': device,
             'message': 'TTS',
             'data': {'data': {'tts_text': tts_text, 'media_stream': media_stream}}
         })
 
-        # dont' set if it's False to not overwrite the media_stream
+        # don't set if it's False so as to not overwrite the media_stream
         if critical:
             self.critical = critical
 

--- a/appdaemon/plugins/hass/notifications.py
+++ b/appdaemon/plugins/hass/notifications.py
@@ -6,7 +6,22 @@ from ...models.notification.android import AndroidData
 
 
 class AndroidNotification(BaseModel, extra='forbid'):
+    """Wrapper for configuring Android notification service calls
+
+    This class is used to create a notification for the Android mobile app and contains some conveniences for correctly
+    customizing the notification.
+
+    Example:
+
+        >>> android_notification = AndroidNotification(
+                device='pixel_9',
+                message='Hello World!',
+                title='AppDaemon',
+            )
+        >>> self.service_call(**android_notification.to_service_call())
+    """
     device: str = Field(serialization_alias='service')
+    """This gets combined with ``notify/mobile_app_<device>`` to determine which notification service to call."""
     message: str = Field(exclude=True)
     title: str | None = Field(default=None, exclude=True)
     tag: str | None = Field(default='apdaemon', exclude=True)
@@ -24,6 +39,7 @@ class AndroidNotification(BaseModel, extra='forbid'):
         return f'notify/mobile_app_{device}'
 
     def to_service_call(self) -> dict:
+        """Dump the configuration to a dictionary that can be directly used with ``call_service``."""
         kwargs = self.model_dump(mode='json', exclude_none=True, by_alias=True)
         if data := kwargs.pop('data', False):
             kwargs.update(data)
@@ -37,10 +53,10 @@ class AndroidNotification(BaseModel, extra='forbid'):
         media_stream: Literal['music_stream', 'alarm_stream', 'alarm_stream_max'] | None = 'music_stream',
         critical: bool = False,
     ) -> 'AndroidNotification':
-        """Creates a special instance of AndroidNotification for TTS notifications.
+        """Create an instance AndroidNotification pre-configured for TTS notifications.
 
         This includes setting the message to `TTS` as described in the Home Assistant documentation. See
-        https://companion.home-assistant.io/docs/notifications/notifications-basic#text-to-speech-notifications
+        `Text To Speech Notifications <https://companion.home-assistant.io/docs/notifications/notifications-basic#text-to-speech-notifications>`_
         for more information.
         """
         self = cls.model_validate({
@@ -57,6 +73,13 @@ class AndroidNotification(BaseModel, extra='forbid'):
 
     @property
     def critical(self):
+        """For Android, notifications will appear immediately in most cases. However, in some cases (such as phone being
+        stationary or when screen has been turned off for prolonged period of time), default notifications will not ring
+        the phone until screen is turned on. To override that behavior, set this property to ``True``.
+
+        See `Critical Notifications <https://companion.home-assistant.io/docs/notifications/critical-notifications/#android>`_
+        for more information.
+        """
         return self.service_data.data.media_stream == 'alarm_stream_max'
 
     @critical.setter
@@ -85,6 +108,7 @@ class AndroidNotification(BaseModel, extra='forbid'):
 
     @countdown.setter
     def countdown(self, new: int):
+
         # https://companion.home-assistant.io/docs/notifications/notifications-basic/#chronometer-notifications
         self.service_data.data.when = new
         self.service_data.data.chronometer = True
@@ -100,11 +124,22 @@ class AndroidNotification(BaseModel, extra='forbid'):
 
     @property
     def persistent(self):
+        """Persistent notifications are notifications that cannot be dismissed by swiping away. These are useful if you
+        have something important like an alarm being triggered. In order to use this property you must set the tag
+        property as well. The persistent property only takes boolean (``true``/``false``) values, with ``false`` being
+        the default. The persistent notification will still be dismissed once selected, to avoid this use the ``sticky``
+        parameter so the notification stays.
+
+        Changing the value of this property will also change the value of the ``sticky`` property automatically because
+        that's usually the intended behavior.
+
+        See `Persistent Notification <https://companion.home-assistant.io/docs/notifications/notifications-basic/#persistent-notification>`_
+        for more information.
+        """
         return self.service_data.data.persistent
 
     @persistent.setter
     def persistent(self, new: bool):
-        # https://companion.home-assistant.io/docs/notifications/notifications-basic/#persistent-notification
         self.service_data.data.persistent = new
         self.service_data.data.sticky = new
 

--- a/appdaemon/sequences.py
+++ b/appdaemon/sequences.py
@@ -170,7 +170,12 @@ class Sequences:
     async def _exec_step(self, step: SequenceStep, default_namespace: str, calling_app: str):
         match step:
             case ServiceCallStep():
-                kwargs = {"namespace": step.namespace or default_namespace, "domain": step.domain, "service": step.service, "name": "sequence", "data": step.model_extra}
+                kwargs = {
+                    "namespace": step.namespace or default_namespace,
+                    "domain": step.domain,
+                    "service": step.service,
+                    "data": step.model_extra
+                }  # fmt: skip
 
                 if loop_step := step.loop_step:
                     for _ in range(loop_step.times):

--- a/appdaemon/stream/adstream.py
+++ b/appdaemon/stream/adstream.py
@@ -331,7 +331,12 @@ class RequestHandler:
 
             service_data = data["data"]
 
-        return await self.AD.services.call_service(data["namespace"], domain, service, service_data)
+        return await self.AD.services.call_service(
+            namespace=data["namespace"],
+            domain=domain,
+            service=service,
+            data=service_data
+        )  # fmt: skip
 
     async def get_state(self, data, request_id):
         if not self.authed:

--- a/appdaemon/utils.py
+++ b/appdaemon/utils.py
@@ -207,7 +207,7 @@ def check_state(logger, new_state, callback_state, name) -> bool:
 
 def sync_decorator(coro_func):  # no type hints here, so that @wraps(func) works properly
     @wraps(coro_func)
-    def wrapper(self, *args, timeout: int | float | None = None, **kwargs):
+    def wrapper(self, *args, timeout: str | int | float | None = None, **kwargs):
         # self.logger.debug(f"Wrapping async function {coro_func.__qualname__}")
         ad: "AppDaemon" = self.AD
 
@@ -270,8 +270,10 @@ def format_seconds(secs):
     return str(timedelta(seconds=secs))
 
 
-def convert_timedelta(s: str | int | float) -> timedelta:
+def convert_timedelta(s: str | int | float | timedelta | None) -> timedelta | None:
     match s:
+        case timedelta():
+            return s
         case int() | float():
             return timedelta(seconds=s)
         case str():
@@ -461,7 +463,7 @@ async def run_in_executor(self, fn, *args, **kwargs) -> Any:
     return await future
 
 
-def run_coroutine_threadsafe(self: "ADBase", coro: Coroutine, timeout: float | None = None) -> Any:
+def run_coroutine_threadsafe(self: "ADBase", coro: Coroutine, timeout: str | int | float | None = None) -> Any:
     """This runs an instantiated coroutine (async) from sync code. This handles the logic for cancelling
     coroutines that run too long.
 
@@ -474,23 +476,24 @@ def run_coroutine_threadsafe(self: "ADBase", coro: Coroutine, timeout: float | N
     Returns:
         Result from the coroutine
     """
-    timeout = timeout or self.AD.internal_function_timeout
+    timeout = timeout or self.AD.config.internal_function_timeout
+    timeout = convert_timedelta(timeout)
 
     if self.AD.loop.is_running():
         future = asyncio.run_coroutine_threadsafe(coro, self.AD.loop)
         try:
-            return future.result(timeout)
+            return future.result(timeout.total_seconds())
         except concurrent.futures.CancelledError:
             self.logger.warning(f"Future cancelled while waiting for coroutine: {coro}")
         except (asyncio.TimeoutError, concurrent.futures.TimeoutError):
             if hasattr(self, "logger"):
                 self.logger.warning(
-                    "Coroutine (%s) took too long (%s seconds), cancelling the task...",
+                    "Coroutine (%s) took too long (%s), cancelling the task...",
                     coro,
-                    timeout,
+                    format_timedelta(timeout),
                 )
             else:
-                print("Coroutine ({}) took too long, cancelling the task...".format(coro))
+                print(f"Coroutine ({coro}) took too long, cancelling the task...")
             future.cancel()
     else:
         self.logger.warning("LOOP NOT RUNNING. Returning NONE.")


### PR DESCRIPTION
Lots of cleanup for call_service

- Docstring updates
- Deprecated `return_result` and `return_response` - AppDaemon automatically determines if it needs to be sent along with the service call.
- `ADAPI.call_service` now uses its `callback` argument to determine whether or not it should immediately return rather than waiting for the result of the service call. Using this `callback` argument will be the recommended way to handle long-lasting service calls. The callback should have this form:
    ```python
        def service_callback(self, result: Any) -> None:
            ...
    ```
- Added `Hass.get_service_info` as a debug tool for easily getting metadata about specific service calls in Home Assistant
- Using `appdaemon.utils.convert_timedelta` extensively, which provides a common way of converting disparate data types into native `timedelta` objects.
  - Includes a couple places in the pydantic models to convert user input into timedelta objects