### PR TITLE
changed __init__ check for user app objects

### DIFF
--- a/appdaemon/app_management.py
+++ b/appdaemon/app_management.py
@@ -488,10 +488,10 @@ class AppManagement:
                 class_name
             )
 
-        if utils.count_positional_arguments(app_class.__init__) != 3:
-            raise ade.BadClassSignature(class_name)
-
         new_obj = app_class(self.AD, cfg)
+        assert isinstance(getattr(new_obj, "AD", None), type(self.AD)), 'App objects need to have a reference to the AppDaemon object'
+        assert isinstance(getattr(new_obj, "config_model", None), AppConfig), 'App objects need to have a reference to their config model'
+
         self.objects[app_name] = ManagedObject(
             type="app",
             object=new_obj,


### PR DESCRIPTION
Closes #2234

Previously, AppDaemon insisted on app objects having an `__init__` call signature of

```python
    def __init__(self, AD: AppDaemon, config_model: AppConfig): ...
```

However this formulation is also valid, which is what the [**qolsysgw**](https://github.com/XaF/qolsysgw) project does.

```python
    def __init__(self, *args, **kwargs):
        ... # custom logic here
        super().__init__(*args, **kwargs)
        ... # custom logic here
```

This seems like a pretty decent sized project, so I think this is an easy accommodation for them. The new check just ensures that the app objects end up with some attributes set.