### PR TITLE
Async revert

### DIFF
--- a/appdaemon/adapi.py
+++ b/appdaemon/adapi.py
@@ -3642,7 +3642,8 @@ class ADAPI:
         self.AD.futures.add_future(self.name, future)
         return future
 
-    def create_task(
+    @utils.sync_decorator
+    async def create_task(
         self,
         coro: Coroutine[Any, Any, T],
         callback: Callable | None = None,

--- a/appdaemon/adbase.py
+++ b/appdaemon/adbase.py
@@ -5,8 +5,9 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from appdaemon import adapi
+from appdaemon import utils
 from appdaemon.models.config.app import AppConfig
-from appdaemon.utils import StateAttrs
+
 
 # Check if the module is being imported using the legacy method
 if __name__ == Path(__file__).name:
@@ -31,7 +32,7 @@ class Entities:  # @todo
         pass
 
     def __get__(self, instance, owner):
-        stateattrs = StateAttrs(instance.get_state())
+        stateattrs = utils.StateAttrs(instance.get_state())
         return stateattrs
 
 
@@ -165,7 +166,8 @@ class ADBase:
     def get_ad_api(self) -> adapi.ADAPI:
         return adapi.ADAPI(self.AD, self.config_model)
 
-    def get_plugin_api(self, plugin_name: str):
+    @utils.sync_decorator
+    async def get_plugin_api(self, plugin_name: str):
         """Get the plugin API for a specific plugin."""
         if isinstance(cfg := self.app_config.root.get(self.name), AppConfig):
             return self.AD.plugins.get_plugin_api(plugin_name, cfg)

--- a/appdaemon/plugins/mqtt/mqttapi.py
+++ b/appdaemon/plugins/mqtt/mqttapi.py
@@ -229,23 +229,17 @@ class Mqtt(adbase.ADBase, adapi.ADAPI):
         result = self.call_service(service, **kwargs)
         return result
 
-    def _run_service_call(self, task: str, topic: Union[str, list], **kwargs: Optional[Any]) -> None:
+    def _run_service_call(self, task: str, topic: str | list[str], **kwargs: Optional[Any]) -> None:
         """Used to process the subscribe/unsubscribe service calls"""
 
         # first we validate the topic
         if not isinstance(topic, (str, list)):
             raise ValueError(f"The given topic {topic} is not supported. Please only strs and lists are supported")
 
-        if isinstance(topic, str):
-            kwargs["topic"] = topic
-            service = f"mqtt/{task}"
-            self.call_service(service, **kwargs)
+        kwargs["topic"] = topic
+        service = f"mqtt/{task}"
+        return self.call_service(service, **kwargs)
 
-        else:  # its a list
-            for t in topic:
-                kwargs["topic"] = t
-                service = f"mqtt/{task}"
-                self.call_service(service, **kwargs)
 
     def mqtt_subscribe(self, topic: Union[str, list], **kwargs: Optional[Any]) -> None:
         """Subscribes to a MQTT topic.
@@ -284,7 +278,7 @@ class Mqtt(adbase.ADBase, adapi.ADAPI):
 
         """
 
-        self._run_service_call("subscribe", topic, **kwargs)
+        return self._run_service_call("subscribe", topic, **kwargs)
 
     def mqtt_unsubscribe(self, topic: Union[str, list], **kwargs: Optional[Any]) -> None:
         """Unsubscribes from a MQTT topic.
@@ -323,7 +317,7 @@ class Mqtt(adbase.ADBase, adapi.ADAPI):
 
         """
 
-        self._run_service_call("unsubscribe", topic, **kwargs)
+        return self._run_service_call("unsubscribe", topic, **kwargs)
 
     @utils.sync_decorator
     async def is_client_connected(self, **kwargs: Optional[Any]) -> bool:


### PR DESCRIPTION
Should close #2277 and #2278

This reverts some behavior when using certain methods from async methods. Some things don't have to be async, and don't really make sense to be anyway. My intent was to leave all that behavior alone for the time being, but seems like I did touch it in a few places.

We'll handle pruning all that stuff out in a more controlled way in a future release.