### PR TITLE
Fix wait_state (broken in 4.5.0)

### DIFF
--- a/appdaemon/entity.py
+++ b/appdaemon/entity.py
@@ -435,7 +435,7 @@ class Entity:
             self.logger.warning(f"State Wait for {self.entity_id} Timed Out")
             raise TimeOutException("The entity timed out") from e
         finally:
-            self._async_events.pop(wait_id)
+            self._async_events.pop(wait_id, None)  # Ignore if already removed
 
     async def entity_state_changed(self, *args, wait_id: str, **kwargs) -> None:
         """The entity state changed"""


### PR DESCRIPTION
A `finally` clause was added to `wait_state` in 4.5.0 to remove the event from `_async_events` in case `entity_state_changed` is never called. However, this creashes in the normal case then  `entity_state_changed` __does__ get called, cause `async_events.pop`  does not find the key and fails.

This tiny PR fixes this bug.