### PR TITLE
fix: add name property to RequestHandler

### DIFF
--- a/appdaemon/stream/adstream.py
+++ b/appdaemon/stream/adstream.py
@@ -102,6 +102,11 @@ class RequestHandler:
         self.stream = self.adstream.stream_handler.makeStream(self.AD, request, on_message=self._on_message, on_disconnect=self._on_disconnect)
         #
 
+    @property
+    def name(self):
+        """Return client_name as name for compatibility"""
+        return self.client_name
+
     async def _on_message(self, data):
         await self._request(data)
 


### PR DESCRIPTION
The exception handler fix for https://github.com/AppDaemon/appdaemon/issues/2282 got me further:

```js
Error in stream: Unknown error occurred, check AppDaemon logs: 'RequestHandler' object has no attribute 'name' {response_type: 'hello', response_id: '9cfb952e-33cc-4304-b620-4e1b2a359e44', response_success: false, response_error: "Unknown error occurred, check AppDaemon logs: 'RequestHandler' object has no attribute 'name'", request: {…}}
```

Adding this then fixed the issue, and data now loads in the admin dashboard.