### PR TITLE
Fix  HASS configuration `cert_verify` not working correctly

### DIFF
--- a/appdaemon/plugins/hass/hassplugin.py
+++ b/appdaemon/plugins/hass/hassplugin.py
@@ -128,8 +128,11 @@ class HassPlugin(PluginBase):
         """Handles creating an :py:class:`~aiohttp.ClientSession` with the cert information from the plugin config
         and the authorization headers for the `REST API <https://developers.home-assistant.io/docs/api/rest>`_.
         """
-        ssl_context = ssl.create_default_context(capath=self.config.cert_path)
-        conn = aiohttp.TCPConnector(ssl_context=ssl_context)
+        if self.config.cert_path is not None:
+            ssl_context = ssl.create_default_context(capath=self.config.cert_path)
+            conn = aiohttp.TCPConnector(ssl_context=ssl_context, verify_ssl=self.config.cert_verify)
+        else:
+            conn = aiohttp.TCPConnector(ssl=False)
 
         connect_timeout_secs = self.config.connect_timeout.total_seconds()
         return aiohttp.ClientSession(

--- a/appdaemon/plugins/hass/hassplugin.py
+++ b/appdaemon/plugins/hass/hassplugin.py
@@ -128,9 +128,9 @@ class HassPlugin(PluginBase):
         """Handles creating an :py:class:`~aiohttp.ClientSession` with the cert information from the plugin config
         and the authorization headers for the `REST API <https://developers.home-assistant.io/docs/api/rest>`_.
         """
-        if self.config.cert_path is not None:
+        if self.config.cert_path is not None or self.config.cert_verify is not False:
             ssl_context = ssl.create_default_context(capath=self.config.cert_path)
-            conn = aiohttp.TCPConnector(ssl_context=ssl_context, verify_ssl=self.config.cert_verify)
+            conn = aiohttp.TCPConnector(ssl_context=ssl_context, ssl=True)
         else:
             conn = aiohttp.TCPConnector(ssl=False)
 

--- a/docs/CONFIGURE.rst
+++ b/docs/CONFIGURE.rst
@@ -554,7 +554,6 @@ An example of the HASS plugin configured with YAML could look like the following
           type: hass
           ha_url: <some_url>
           token: <token>
-          cert_path: <path/to/root/CA/cert>
           cert_verify: True
           namespace: default
 
@@ -583,7 +582,6 @@ Or in TOML:
   type = "hass"
   ha_url = "<some_url>"
   token = "<token>"
-  cert_path = "<path/to/root/CA/cert>"
   cert_verify = true
   namespace = "default"
 

--- a/docs/HASS_API_REFERENCE.rst
+++ b/docs/HASS_API_REFERENCE.rst
@@ -73,9 +73,6 @@ This is the full list of configuration options available for the `Hass` plugin.
    * - ``cert_verify``
      - optional
      - Flag for adding an SSL context around the ``aiohttp.ClientSession``. Set to ``False`` to disable (e.g., with internal IPs)
-   * - ``cert_path``
-     - optional
-     - Path to the SSL certificate file. This is only used if ``cert_verify`` is set to ``True``.
    * - ``api_port``
      - optional
      - Port the AppDaemon RESTful API will listen on. If not specified, API is disabled


### PR DESCRIPTION
This commit fixes a regression that caused HASS config option `cert_verify` to not be applied correctly.