### PR TITLE
Only rebuild the Python dependency graph when files changed (#2599)

### DIFF
--- a/tests/unit/test_dependency_manager.py
+++ b/tests/unit/test_dependency_manager.py
@@ -1,0 +1,123 @@
+"""Tests for the dependency graph refresh in ``appdaemon.dependency_manager``."""
+
+import os
+from pathlib import Path
+
+import pytest
+from appdaemon.dependency_manager import AppDeps, Dependencies, PythonDeps
+
+pytestmark = [
+    pytest.mark.ci,
+    pytest.mark.unit,
+]
+
+
+MODULE_A = """\
+import os
+
+
+def a():
+    return os.getcwd()
+"""
+
+MODULE_B = """\
+import module_a
+
+
+def b():
+    return module_a.a()
+"""
+
+
+@pytest.fixture
+def app_dir(tmp_path: Path) -> Path:
+    (tmp_path / "module_a.py").write_text(MODULE_A)
+    (tmp_path / "module_b.py").write_text(MODULE_B)
+    return tmp_path
+
+
+def python_files(path: Path) -> set[Path]:
+    return set(path.glob("*.py"))
+
+
+class CountingPythonDeps(PythonDeps):
+    """``PythonDeps`` that records how often the graph was actually rebuilt."""
+
+    def refresh_dep_graph(self):
+        self.refresh_count = getattr(self, "refresh_count", 0) + 1
+        return super().refresh_dep_graph()
+
+
+def test_graph_is_built_on_init(app_dir: Path):
+    deps = CountingPythonDeps.from_paths(python_files(app_dir))
+
+    assert deps.refresh_count == 1
+    assert deps.dep_graph["module_b"] == {"module_a"}
+
+
+def test_unchanged_files_do_not_rebuild_the_graph(app_dir: Path):
+    """The utility loop calls ``update`` on every pass; re-parsing every file
+    each time is what makes ``check_app_updates`` cost seconds (issue #2599)."""
+    deps = CountingPythonDeps.from_paths(python_files(app_dir))
+    before = deps.refresh_count
+    graph_before = dict(deps.dep_graph)
+
+    for _ in range(5):
+        deps.update(python_files(app_dir))
+
+    assert deps.refresh_count == before
+    assert deps.dep_graph == graph_before
+
+
+@pytest.mark.parametrize("change", ["modified", "new", "deleted"])
+def test_changed_files_rebuild_the_graph(app_dir: Path, change: str):
+    deps = CountingPythonDeps.from_paths(python_files(app_dir))
+    before = deps.refresh_count
+
+    if change == "modified":
+        target = app_dir / "module_b.py"
+        target.write_text(MODULE_B + "\nimport json\n")
+        # mtime resolution can be coarse enough to hide a same-instant write
+        stat = target.stat()
+        os.utime(target, (stat.st_atime, stat.st_mtime + 10))
+    elif change == "new":
+        (app_dir / "module_c.py").write_text(MODULE_A)
+    else:
+        (app_dir / "module_b.py").unlink()
+
+    deps.update(python_files(app_dir))
+
+    assert deps.refresh_count == before + 1
+
+
+def test_fixing_a_bad_file_retries_it(app_dir: Path):
+    """A file that failed to parse is retried once it changes, because the fixed
+    file lands in ``FileCheck.modified``."""
+    broken = app_dir / "module_broken.py"
+    broken.write_text("def oops(:\n")
+
+    deps = CountingPythonDeps.from_paths(python_files(app_dir))
+    assert broken in {path for path, _ in deps.bad_files}
+
+    # Nothing changed: the bad file stays parked, no rebuild.
+    before = deps.refresh_count
+    deps.update(python_files(app_dir))
+    assert deps.refresh_count == before
+    assert broken in {path for path, _ in deps.bad_files}
+
+    broken.write_text(MODULE_A)
+    stat = broken.stat()
+    os.utime(broken, (stat.st_atime, stat.st_mtime + 10))
+
+    deps.update(python_files(app_dir))
+
+    assert deps.refresh_count == before + 1
+    assert broken not in {path for path, _ in deps.bad_files}
+    assert "module_broken" in deps.dep_graph
+
+
+def test_app_deps_still_refresh_unconditionally():
+    """Only ``PythonDeps`` opts out: ``AppDeps.refresh_dep_graph`` is cheap and
+    walks the already-parsed app config rather than the filesystem."""
+    assert AppDeps.needs_refresh is Dependencies.needs_refresh
+    assert PythonDeps.needs_refresh is not Dependencies.needs_refresh


### PR DESCRIPTION
Fixes #2599.

## The problem

`PythonDeps.refresh_dep_graph` reads and `ast.parse`s **every** Python file under the apps directory. `Dependencies.update` calls it unconditionally, and `check_app_updates` calls `update` on every utility-loop iteration — so every pass re-parses the entire app tree even when nothing was touched.

Measured on a live install (79 app files, 2.76 MB, AppDaemon 4.5.13, Python 3.12), replaying the exact code path in-container:

```
py files considered : 79        total source bytes : 2,757,075
walk (iterdir+stat) :    17.5 ms
FileCheck stat pass :     0.9 ms
get_dependency_graph:  2235.3 ms  (failed=0)
  - pure read       :    13.5 ms
  - pure ast.parse  :  2191.8 ms
```

98% of the cost is `ast.parse`. Reading the files is 13 ms — this is CPU, not I/O.

It compounds: once the pass exceeds `max_utility_skew`, `utility_loop` skips its own sleep, so the loop goes hot. Measured from inside the container (482 sequential requests over 15 s):

```
slow (>200ms): 6, sum 12.91 s   max 2.240 s   median 0.0017 s
blocked fraction: 0.86
```

86% of the event loop blocked in ~2.2 s chunks every ~2.4 s, container pinned at 102% CPU. Because app-side sync API calls go through `run_coroutine_threadsafe` onto that same loop, app callbacks arrive up to ~2.4 s late — visible in app logs as stalls mid-callback.

## The fix

`FileCheck.update` has already computed the new/modified/deleted sets by the time `refresh_dep_graph` is called, so it already knows whether anything needs re-parsing. This gates the refresh on `there_were_changes` via a `needs_refresh` hook, overridden **only** in `PythonDeps`.

`AppDeps` deliberately keeps refreshing unconditionally: its `refresh_dep_graph` walks the already-parsed app config rather than the filesystem, so it is cheap, and it is also called explicitly elsewhere when app configs change.

Files that previously failed to parse are still retried — a fixed file has a new mtime and therefore lands in `FileCheck.modified`. There is a test for exactly that.

## Tests

Adds `tests/unit/test_dependency_manager.py` (7 tests): graph built on init; unchanged files do not rebuild; new/modified/deleted each do rebuild; a fixed bad file is retried; `AppDeps` still refreshes unconditionally. Three of them fail on `dev` and pass with the change. Full unit suite: 209 passed.

## Note

This is a targeted fix, not the `watchdog`/inotify rework mentioned in #1897 — it just stops the redundant work. Raising `utility_delay` is a workaround but costs reload latency; this keeps detection at the normal interval.